### PR TITLE
Add Helm chart skeleton

### DIFF
--- a/charts/bibind-orchestration/Chart.yaml
+++ b/charts/bibind-orchestration/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: bibind-orchestration
+description: A Helm chart for Bibind orchestration
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/charts/bibind-orchestration/templates/configmap-env.yaml
+++ b/charts/bibind-orchestration/templates/configmap-env.yaml
@@ -1,0 +1,7 @@
+# Environment configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bibind-env
+data:
+  SAMPLE_ENV: "value"

--- a/charts/bibind-orchestration/templates/deployment-apibibind.yaml
+++ b/charts/bibind-orchestration/templates/deployment-apibibind.yaml
@@ -1,0 +1,18 @@
+# Deployment for API Bibind
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: apibibind
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: apibibind
+  template:
+    metadata:
+      labels:
+        app: apibibind
+    spec:
+      containers:
+        - name: apibibind
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/charts/bibind-orchestration/templates/deployment-orchestrateur-principal.yaml
+++ b/charts/bibind-orchestration/templates/deployment-orchestrateur-principal.yaml
@@ -1,0 +1,18 @@
+# Deployment for main orchestrator
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orchestrateur-principal
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: orchestrateur-principal
+  template:
+    metadata:
+      labels:
+        app: orchestrateur-principal
+    spec:
+      containers:
+        - name: orchestrateur-principal
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/charts/bibind-orchestration/templates/deployment-so-conception.yaml
+++ b/charts/bibind-orchestration/templates/deployment-so-conception.yaml
@@ -1,0 +1,18 @@
+# Deployment for service conception
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: so-conception
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: so-conception
+  template:
+    metadata:
+      labels:
+        app: so-conception
+    spec:
+      containers:
+        - name: so-conception
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/charts/bibind-orchestration/templates/deployment-so-plannification.yaml
+++ b/charts/bibind-orchestration/templates/deployment-so-plannification.yaml
@@ -1,0 +1,18 @@
+# Deployment for service plannification
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: so-plannification
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: so-plannification
+  template:
+    metadata:
+      labels:
+        app: so-plannification
+    spec:
+      containers:
+        - name: so-plannification
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/charts/bibind-orchestration/templates/ingress.yaml
+++ b/charts/bibind-orchestration/templates/ingress.yaml
@@ -1,0 +1,16 @@
+# Ingress configuration
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bibind-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: apibibind
+                port:
+                  number: 80

--- a/charts/bibind-orchestration/templates/service-so-conception.yaml
+++ b/charts/bibind-orchestration/templates/service-so-conception.yaml
@@ -1,0 +1,11 @@
+# Service for service conception
+apiVersion: v1
+kind: Service
+metadata:
+  name: so-conception
+spec:
+  selector:
+    app: so-conception
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/charts/bibind-orchestration/templates/service-so-plannification.yaml
+++ b/charts/bibind-orchestration/templates/service-so-plannification.yaml
@@ -1,0 +1,11 @@
+# Service for service plannification
+apiVersion: v1
+kind: Service
+metadata:
+  name: so-plannification
+spec:
+  selector:
+    app: so-plannification
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/charts/bibind-orchestration/values.yaml
+++ b/charts/bibind-orchestration/values.yaml
@@ -1,0 +1,6 @@
+# Default values for bibind-orchestration.
+replicaCount: 1
+image:
+  repository: your-repo/bibind
+  tag: "latest"
+  pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
- add helm chart skeleton under `charts/bibind-orchestration`
- include placeholder deployments, services, ingress and configmap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f29c7784832587f70ff41c7898ea