### PR TITLE
Add so_realisation microservice skeleton

### DIFF
--- a/Bibind/so_realisation/Dockerfile
+++ b/Bibind/so_realisation/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+# Dépendances système
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc curl git build-essential libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Création des dossiers applicatifs
+WORKDIR /app
+
+# Ajout des fichiers de dépendances
+COPY requirements.txt .
+
+# Installation des dépendances Python
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Copie du code
+COPY . .
+
+# Port par défaut
+EXPOSE 8000
+
+# Lancement de FastAPI via Uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Bibind/so_realisation/__init__.py
+++ b/Bibind/so_realisation/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_realisation/client/__init__.py
+++ b/Bibind/so_realisation/client/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_realisation/client/api_bibind_client.py
+++ b/Bibind/so_realisation/client/api_bibind_client.py
@@ -1,0 +1,9 @@
+"""Client used to notify the Bibind API of progress."""
+
+import httpx
+
+
+async def notify(status: str) -> None:
+    """Send status update to the Bibind API."""
+    async with httpx.AsyncClient() as client:
+        await client.post("http://apibibind/notify", json={"status": status})

--- a/Bibind/so_realisation/kafka/__init__.py
+++ b/Bibind/so_realisation/kafka/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_realisation/kafka/consumer.py
+++ b/Bibind/so_realisation/kafka/consumer.py
@@ -1,0 +1,17 @@
+"""Kafka consumer to trigger realisation workflows."""
+
+from threading import Thread
+from kafka import KafkaConsumer
+
+
+def _listen() -> None:
+    consumer = KafkaConsumer('realisation-topic')
+    for msg in consumer:
+        # TODO: handle incoming messages
+        print(msg.value)
+
+
+def start_kafka_listener() -> None:
+    """Start Kafka consumer in a background thread."""
+    thread = Thread(target=_listen, daemon=True)
+    thread.start()

--- a/Bibind/so_realisation/kafka/producer.py
+++ b/Bibind/so_realisation/kafka/producer.py
@@ -1,0 +1,8 @@
+"""Optional Kafka producer for realisation events."""
+
+from kafka import KafkaProducer
+
+
+def get_producer() -> KafkaProducer:
+    """Create and return a KafkaProducer instance."""
+    return KafkaProducer()

--- a/Bibind/so_realisation/langgraph/__init__.py
+++ b/Bibind/so_realisation/langgraph/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_realisation/langgraph/realisation_graph.py
+++ b/Bibind/so_realisation/langgraph/realisation_graph.py
@@ -1,0 +1,10 @@
+"""LangGraph implementation for the realisation step."""
+
+from langgraph import Graph
+
+
+def build_realisation_graph() -> Graph:
+    """Return a LangGraph instance for the realisation workflow."""
+    graph = Graph()
+    # TODO: define nodes and edges
+    return graph

--- a/Bibind/so_realisation/langgraph/tools.py
+++ b/Bibind/so_realisation/langgraph/tools.py
@@ -1,0 +1,9 @@
+"""Utility functions and agent tools for the realisation graph."""
+
+from typing import Any
+
+
+def get_llm() -> Any:
+    """Return an LLM instance (placeholder)."""
+    # TODO: connect to Ollama or other LLM provider
+    return None

--- a/Bibind/so_realisation/main.py
+++ b/Bibind/so_realisation/main.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+from routes import realisation
+from kafka.consumer import start_kafka_listener
+
+app = FastAPI(title="SO - Realisation")
+
+# Inclusion des routes
+app.include_router(realisation.router)
+
+# Kafka listener
+@app.on_event("startup")
+async def startup_event():
+    start_kafka_listener()

--- a/Bibind/so_realisation/models/__init__.py
+++ b/Bibind/so_realisation/models/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_realisation/models/db_models.py
+++ b/Bibind/so_realisation/models/db_models.py
@@ -1,0 +1,10 @@
+"""Optional SQLAlchemy ORM models."""
+
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+# Example model
+# class Example(Base):
+#     __tablename__ = "example"
+#     id = Column(Integer, primary_key=True)

--- a/Bibind/so_realisation/orchestrator/__init__.py
+++ b/Bibind/so_realisation/orchestrator/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_realisation/orchestrator/engine.py
+++ b/Bibind/so_realisation/orchestrator/engine.py
@@ -1,0 +1,16 @@
+"""Engine that orchestrates the realisation step."""
+
+from langgraph import Graph
+from langgraph import Runner
+from langgraph import Node
+
+
+class RealisationEngine:
+    """Simple wrapper around LangGraph Runner."""
+
+    def __init__(self, graph: Graph) -> None:
+        self.runner = Runner(graph)
+
+    def run(self) -> None:
+        """Execute the realisation workflow."""
+        self.runner.run()

--- a/Bibind/so_realisation/requirements.txt
+++ b/Bibind/so_realisation/requirements.txt
@@ -1,0 +1,10 @@
+fastapi==0.110.0
+uvicorn==0.27.0
+langchain
+langgraph
+kafka-python
+pydantic
+httpx
+python-dotenv
+flytekit
+ollama

--- a/Bibind/so_realisation/routes/__init__.py
+++ b/Bibind/so_realisation/routes/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_realisation/routes/realisation.py
+++ b/Bibind/so_realisation/routes/realisation.py
@@ -1,0 +1,14 @@
+"""API routes for the realisation service."""
+
+from fastapi import APIRouter
+from schemas.realisation_input import RealisationInput
+from schemas.realisation_output import RealisationOutput
+from services.realisation_agent import generate_realisation
+
+router = APIRouter(prefix="/realisation", tags=["realisation"])
+
+
+@router.post("/", response_model=RealisationOutput)
+async def run_realisation(payload: RealisationInput) -> RealisationOutput:
+    """Trigger the realisation workflow and return the result."""
+    return await generate_realisation(payload)

--- a/Bibind/so_realisation/schemas/__init__.py
+++ b/Bibind/so_realisation/schemas/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_realisation/schemas/realisation_input.py
+++ b/Bibind/so_realisation/schemas/realisation_input.py
@@ -1,0 +1,9 @@
+"""Pydantic schema for realisation input."""
+
+from pydantic import BaseModel
+
+
+class RealisationInput(BaseModel):
+    """Input data required to run the realisation service."""
+
+    data: str

--- a/Bibind/so_realisation/schemas/realisation_output.py
+++ b/Bibind/so_realisation/schemas/realisation_output.py
@@ -1,0 +1,9 @@
+"""Pydantic schema for realisation output."""
+
+from pydantic import BaseModel
+
+
+class RealisationOutput(BaseModel):
+    """Result produced by the realisation service."""
+
+    result: str

--- a/Bibind/so_realisation/services/__init__.py
+++ b/Bibind/so_realisation/services/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_realisation/services/realisation_agent.py
+++ b/Bibind/so_realisation/services/realisation_agent.py
@@ -1,0 +1,10 @@
+"""Logic to generate realisation output using LLM/LangChain."""
+
+from schemas.realisation_input import RealisationInput
+from schemas.realisation_output import RealisationOutput
+
+
+async def generate_realisation(payload: RealisationInput) -> RealisationOutput:
+    """Stub implementation that returns a simple response."""
+    # TODO: integrate LangChain/Ollama logic here
+    return RealisationOutput(result="Realisation generated")

--- a/Bibind/so_realisation/services/registry.py
+++ b/Bibind/so_realisation/services/registry.py
@@ -1,0 +1,7 @@
+"""Register generated realisation results in a catalog."""
+
+
+def register_in_catalog(data: dict) -> None:
+    """Placeholder for registration logic."""
+    # TODO: integrate with real catalog/DB
+    pass

--- a/Bibind/so_realisation/services/validation.py
+++ b/Bibind/so_realisation/services/validation.py
@@ -1,0 +1,7 @@
+"""Validation system for realisation results."""
+
+
+def validate_result(result: str) -> bool:
+    """Placeholder validation logic."""
+    # TODO: implement human/automatic validation
+    return True

--- a/Bibind/so_realisation/tests/__init__.py
+++ b/Bibind/so_realisation/tests/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_realisation/tests/test_realisation.py
+++ b/Bibind/so_realisation/tests/test_realisation.py
@@ -1,0 +1,11 @@
+"""Unit tests for the realisation service."""
+
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_healthcheck() -> None:
+    response = client.get("/docs")
+    assert response.status_code == 200

--- a/Bibind/so_realisation/utils/__init__.py
+++ b/Bibind/so_realisation/utils/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_realisation/utils/flyte_client.py
+++ b/Bibind/so_realisation/utils/flyte_client.py
@@ -1,0 +1,12 @@
+"""Wrapper around the Flyte SDK."""
+
+from flytekit import task, workflow
+
+
+def dummy_task() -> str:
+    return "ok"
+
+
+@workflow
+def dummy_workflow() -> str:
+    return dummy_task()

--- a/Bibind/so_realisation/utils/logging.py
+++ b/Bibind/so_realisation/utils/logging.py
@@ -1,0 +1,8 @@
+"""Centralised logging configuration."""
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    logging.basicConfig(level=logging.INFO)
+    return logging.getLogger(name)

--- a/Bibind/so_realisation/utils/ollama_client.py
+++ b/Bibind/so_realisation/utils/ollama_client.py
@@ -1,0 +1,7 @@
+"""Client to interface with Ollama LLM."""
+
+
+def generate(prompt: str) -> str:
+    """Placeholder function to query Ollama."""
+    # TODO: implement actual Ollama client calls
+    return "response"

--- a/Bibind/so_realisation/utils/token_utils.py
+++ b/Bibind/so_realisation/utils/token_utils.py
@@ -1,0 +1,7 @@
+"""Utility functions for token verification."""
+
+
+def verify_token(token: str) -> bool:
+    """Placeholder token verification."""
+    # TODO: implement verification logic
+    return True


### PR DESCRIPTION
## Summary
- implement new `Bibind/so_realisation` package following the existing SO microservice layout
- include FastAPI entrypoint, Dockerfile and requirements
- add Kafka consumer/producer stubs and LangGraph scaffolding
- provide Pydantic schemas, services, utils, and minimal unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `fastapi`)*

------
https://chatgpt.com/codex/tasks/task_e_6889e1d6a7e883258f586eccaa4392b1