### PR TITLE
Add qualite service skeleton

### DIFF
--- a/Bibind/so_qualite/Dockerfile
+++ b/Bibind/so_qualite/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+# Dépendances système
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc curl git build-essential libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Création des dossiers applicatifs
+WORKDIR /app
+
+# Ajout des fichiers de dépendances
+COPY requirements.txt .
+
+# Installation des dépendances Python
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Copie du code
+COPY . .
+
+# Port par défaut
+EXPOSE 8000
+
+# Lancement de FastAPI via Uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Bibind/so_qualite/__init__.py
+++ b/Bibind/so_qualite/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_qualite/client/__init__.py
+++ b/Bibind/so_qualite/client/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_qualite/client/api_bibind_client.py
+++ b/Bibind/so_qualite/client/api_bibind_client.py
@@ -1,0 +1,9 @@
+"""Client used to notify the Bibind API of progress."""
+
+import httpx
+
+
+async def notify(status: str) -> None:
+    """Send status update to the Bibind API."""
+    async with httpx.AsyncClient() as client:
+        await client.post("http://apibibind/notify", json={"status": status})

--- a/Bibind/so_qualite/kafka/__init__.py
+++ b/Bibind/so_qualite/kafka/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_qualite/kafka/consumer.py
+++ b/Bibind/so_qualite/kafka/consumer.py
@@ -1,0 +1,17 @@
+"""Kafka consumer to trigger qualite workflows."""
+
+from threading import Thread
+from kafka import KafkaConsumer
+
+
+def _listen():
+    consumer = KafkaConsumer('qualite-topic')
+    for msg in consumer:
+        # TODO: handle incoming messages
+        print(msg.value)
+
+
+def start_kafka_listener() -> None:
+    """Start Kafka consumer in a background thread."""
+    thread = Thread(target=_listen, daemon=True)
+    thread.start()

--- a/Bibind/so_qualite/kafka/producer.py
+++ b/Bibind/so_qualite/kafka/producer.py
@@ -1,0 +1,8 @@
+"""Optional Kafka producer for qualite events."""
+
+from kafka import KafkaProducer
+
+
+def get_producer() -> KafkaProducer:
+    """Create and return a KafkaProducer instance."""
+    return KafkaProducer()

--- a/Bibind/so_qualite/langgraph/__init__.py
+++ b/Bibind/so_qualite/langgraph/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_qualite/langgraph/qualite_graph.py
+++ b/Bibind/so_qualite/langgraph/qualite_graph.py
@@ -1,0 +1,10 @@
+"""LangGraph implementation for the qualite step."""
+
+from langgraph import Graph
+
+
+def build_qualite_graph() -> Graph:
+    """Return a LangGraph instance for the qualite workflow."""
+    graph = Graph()
+    # TODO: define nodes and edges
+    return graph

--- a/Bibind/so_qualite/langgraph/tools.py
+++ b/Bibind/so_qualite/langgraph/tools.py
@@ -1,0 +1,9 @@
+"""Utility functions and agent tools for the qualite graph."""
+
+from typing import Any
+
+
+def get_llm() -> Any:
+    """Return an LLM instance (placeholder)."""
+    # TODO: connect to Ollama or other LLM provider
+    return None

--- a/Bibind/so_qualite/main.py
+++ b/Bibind/so_qualite/main.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+from routes import qualite
+from kafka.consumer import start_kafka_listener
+
+app = FastAPI(title="SO - Qualite")
+
+# Inclusion des routes
+app.include_router(qualite.router)
+
+# Kafka listener
+@app.on_event("startup")
+async def startup_event():
+    start_kafka_listener()

--- a/Bibind/so_qualite/models/__init__.py
+++ b/Bibind/so_qualite/models/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_qualite/models/db_models.py
+++ b/Bibind/so_qualite/models/db_models.py
@@ -1,0 +1,10 @@
+"""Optional SQLAlchemy ORM models."""
+
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+# Example model
+# class Example(Base):
+#     __tablename__ = "example"
+#     id = Column(Integer, primary_key=True)

--- a/Bibind/so_qualite/orchestrator/__init__.py
+++ b/Bibind/so_qualite/orchestrator/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_qualite/orchestrator/engine.py
+++ b/Bibind/so_qualite/orchestrator/engine.py
@@ -1,0 +1,16 @@
+"""Engine that orchestrates the qualite step."""
+
+from langgraph import Graph
+from langgraph import Runner
+from langgraph import Node
+
+
+class QualiteEngine:
+    """Simple wrapper around LangGraph Runner."""
+
+    def __init__(self, graph: Graph) -> None:
+        self.runner = Runner(graph)
+
+    def run(self) -> None:
+        """Execute the qualite workflow."""
+        self.runner.run()

--- a/Bibind/so_qualite/requirements.txt
+++ b/Bibind/so_qualite/requirements.txt
@@ -1,0 +1,10 @@
+fastapi==0.110.0
+uvicorn==0.27.0
+langchain
+langgraph
+kafka-python
+pydantic
+httpx
+python-dotenv
+flytekit
+ollama

--- a/Bibind/so_qualite/routes/__init__.py
+++ b/Bibind/so_qualite/routes/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_qualite/routes/qualite.py
+++ b/Bibind/so_qualite/routes/qualite.py
@@ -1,0 +1,14 @@
+"""API routes for the qualite service."""
+
+from fastapi import APIRouter
+from schemas.qualite_input import QualiteInput
+from schemas.qualite_output import QualiteOutput
+from services.qualite_agent import generate_qualite
+
+router = APIRouter(prefix="/qualite", tags=["qualite"])
+
+
+@router.post("/", response_model=QualiteOutput)
+async def run_qualite(payload: QualiteInput) -> QualiteOutput:
+    """Trigger the qualite workflow and return the result."""
+    return await generate_qualite(payload)

--- a/Bibind/so_qualite/schemas/__init__.py
+++ b/Bibind/so_qualite/schemas/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_qualite/schemas/qualite_input.py
+++ b/Bibind/so_qualite/schemas/qualite_input.py
@@ -1,0 +1,9 @@
+"""Pydantic schema for qualite input."""
+
+from pydantic import BaseModel
+
+
+class QualiteInput(BaseModel):
+    """Input data required to run the qualite service."""
+
+    data: str

--- a/Bibind/so_qualite/schemas/qualite_output.py
+++ b/Bibind/so_qualite/schemas/qualite_output.py
@@ -1,0 +1,9 @@
+"""Pydantic schema for qualite output."""
+
+from pydantic import BaseModel
+
+
+class QualiteOutput(BaseModel):
+    """Result produced by the qualite service."""
+
+    result: str

--- a/Bibind/so_qualite/services/__init__.py
+++ b/Bibind/so_qualite/services/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_qualite/services/qualite_agent.py
+++ b/Bibind/so_qualite/services/qualite_agent.py
@@ -1,0 +1,10 @@
+"""Logic to generate qualite output using LLM/LangChain."""
+
+from schemas.qualite_input import QualiteInput
+from schemas.qualite_output import QualiteOutput
+
+
+async def generate_qualite(payload: QualiteInput) -> QualiteOutput:
+    """Stub implementation that returns a simple response."""
+    # TODO: integrate LangChain/Ollama logic here
+    return QualiteOutput(result="Qualite generated")

--- a/Bibind/so_qualite/services/registry.py
+++ b/Bibind/so_qualite/services/registry.py
@@ -1,0 +1,7 @@
+"""Register generated qualite results in a catalog."""
+
+
+def register_in_catalog(data: dict) -> None:
+    """Placeholder for registration logic."""
+    # TODO: integrate with real catalog/DB
+    pass

--- a/Bibind/so_qualite/services/validation.py
+++ b/Bibind/so_qualite/services/validation.py
@@ -1,0 +1,7 @@
+"""Validation system for qualite results."""
+
+
+def validate_result(result: str) -> bool:
+    """Placeholder validation logic."""
+    # TODO: implement human/automatic validation
+    return True

--- a/Bibind/so_qualite/tests/__init__.py
+++ b/Bibind/so_qualite/tests/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_qualite/tests/test_qualite.py
+++ b/Bibind/so_qualite/tests/test_qualite.py
@@ -1,0 +1,11 @@
+"""Unit tests for the qualite service."""
+
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_healthcheck() -> None:
+    response = client.get("/docs")
+    assert response.status_code == 200

--- a/Bibind/so_qualite/utils/__init__.py
+++ b/Bibind/so_qualite/utils/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/Bibind/so_qualite/utils/flyte_client.py
+++ b/Bibind/so_qualite/utils/flyte_client.py
@@ -1,0 +1,12 @@
+"""Wrapper around the Flyte SDK."""
+
+from flytekit import task, workflow
+
+
+def dummy_task() -> str:
+    return "ok"
+
+
+@workflow
+def dummy_workflow() -> str:
+    return dummy_task()

--- a/Bibind/so_qualite/utils/logging.py
+++ b/Bibind/so_qualite/utils/logging.py
@@ -1,0 +1,8 @@
+"""Centralised logging configuration."""
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    logging.basicConfig(level=logging.INFO)
+    return logging.getLogger(name)

--- a/Bibind/so_qualite/utils/ollama_client.py
+++ b/Bibind/so_qualite/utils/ollama_client.py
@@ -1,0 +1,7 @@
+"""Client to interface with Ollama LLM."""
+
+
+def generate(prompt: str) -> str:
+    """Placeholder function to query Ollama."""
+    # TODO: implement actual Ollama client calls
+    return "response"

--- a/Bibind/so_qualite/utils/token_utils.py
+++ b/Bibind/so_qualite/utils/token_utils.py
@@ -1,0 +1,7 @@
+"""Utility functions for token verification."""
+
+
+def verify_token(token: str) -> bool:
+    """Placeholder token verification."""
+    # TODO: implement verification logic
+    return True


### PR DESCRIPTION
## Summary
- introduce `so_qualite` microservice skeleton similar to other services
- include Dockerfile and requirements
- add FastAPI entry point and placeholder logic
- provide Pydantic schemas, routes and utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6889e3868c3883258fac50fd3867db55