### PR TITLE
Add env settings for op_bootstrap

### DIFF
--- a/Bibind/op_bootstrap/.env.example
+++ b/Bibind/op_bootstrap/.env.example
@@ -1,0 +1,26 @@
+# Example environment configuration for Operational Bootstrap
+
+# General environment
+ENV=dev
+
+# Database configuration
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=bibind
+DB_USER=bibind
+DB_PASSWORD=secret
+DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}
+
+# Kafka configuration
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+KAFKA_TOPIC=events
+
+# Vault configuration
+VAULT_ADDR=http://vault:8200
+VAULT_TOKEN=changeme
+
+# Keycloak configuration
+KEYCLOAK_URL=http://keycloak:8080
+KEYCLOAK_REALM=bibind
+KEYCLOAK_CLIENT_ID=my-client
+KEYCLOAK_CLIENT_SECRET=super-secret

--- a/Bibind/op_bootstrap/app/settings.py
+++ b/Bibind/op_bootstrap/app/settings.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from dotenv import load_dotenv
+from pydantic import BaseSettings
+
+# Load environment variables from .env if present
+load_dotenv(dotenv_path=Path(__file__).resolve().parent.parent / '.env')
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    env: str = "dev"
+    database_url: str | None = None
+    kafka_bootstrap_servers: str | None = None
+    kafka_topic: str | None = None
+    vault_addr: str | None = None
+    vault_token: str | None = None
+    keycloak_url: str | None = None
+    keycloak_realm: str | None = None
+    keycloak_client_id: str | None = None
+    keycloak_client_secret: str | None = None
+
+    class Config:
+        env_file = Path(__file__).resolve().parent.parent / '.env'
+        case_sensitive = False
+
+settings = Settings()
+

--- a/Bibind/op_bootstrap/requirements.txt
+++ b/Bibind/op_bootstrap/requirements.txt
@@ -1,4 +1,11 @@
 fastapi
 uvicorn
 SQLAlchemy
+psycopg2-binary
+aiokafka
+langchain
+langgraph
+flytekit
+python-keycloak
+python-dotenv
 pydantic

--- a/Bibind/op_bootstrap/settings.py
+++ b/Bibind/op_bootstrap/settings.py
@@ -1,5 +1,5 @@
 """Application settings loader."""
 
-import os
+from app.settings import Settings, settings
 
-ENV = os.getenv("ENV", "dev")
+__all__ = ["Settings", "settings"]


### PR DESCRIPTION
## Summary
- add settings loader and example `.env`
- expose settings module from `op_bootstrap`
- list runtime dependencies in `requirements.txt`

## Testing
- `pytest -q Bibind/op_bootstrap/app/tests`

------
https://chatgpt.com/codex/tasks/task_e_688b7655a69c8325b7b4836cf1ae1650