### PR TITLE
Configure database and basic ORM

### DIFF
--- a/Bibind/op_bootstrap/alembic.ini
+++ b/Bibind/op_bootstrap/alembic.ini
@@ -1,3 +1,3 @@
 [alembic]
 script_location = alembic
-sqlalchemy.url = sqlite:///./app.db
+sqlalchemy.url = postgresql://localhost/bibind

--- a/Bibind/op_bootstrap/alembic/env.py
+++ b/Bibind/op_bootstrap/alembic/env.py
@@ -1,0 +1,45 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from app.config.database import SQLALCHEMY_DATABASE_URL
+from app.models import Base  # ensure models are imported
+import app.models  # noqa: F401
+
+config = context.config
+fileConfig(config.config_file_name)
+config.set_main_option("sqlalchemy.url", SQLALCHEMY_DATABASE_URL)
+
+target_metadata = Base.metadata
+
+def run_migrations_offline():
+    context.configure(
+        url=SQLALCHEMY_DATABASE_URL,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/Bibind/op_bootstrap/alembic/script.py.mako
+++ b/Bibind/op_bootstrap/alembic/script.py.mako
@@ -1,0 +1,16 @@
+<%text>#
+# This file is part of Alembic.
+# It is provided here for convenience, mostly to generate migration
+# scripts via `alembic revision --autogenerate`.
+#</%text>
+
+from alembic import op
+import sqlalchemy as sa
+
+${imports if imports else ""}
+
+def upgrade():
+${upgrades if upgrades else "    pass"}
+
+def downgrade():
+${downgrades if downgrades else "    pass"}

--- a/Bibind/op_bootstrap/alembic/versions/0001_initial.py
+++ b/Bibind/op_bootstrap/alembic/versions/0001_initial.py
@@ -1,0 +1,90 @@
+"""Initial tables"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0001_initial'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'organisations',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(), nullable=False, unique=True),
+    )
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('email', sa.String(), nullable=False, unique=True),
+        sa.Column('hashed_password', sa.String(), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default='1'),
+        sa.Column('organisation_id', sa.Integer, sa.ForeignKey('organisations.id')),
+    )
+    op.create_table(
+        'projets',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('organisation_id', sa.Integer, sa.ForeignKey('organisations.id')),
+    )
+    op.create_table(
+        'offres',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('description', sa.String()),
+        sa.Column('projet_id', sa.Integer, sa.ForeignKey('projets.id')),
+    )
+    op.create_table(
+        'groupes',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+    )
+    op.create_table(
+        'infrastructures',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+    )
+    op.create_table(
+        'inventories',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+    )
+    op.create_table(
+        'machine_definitions',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+    )
+    op.create_table(
+        'modules_infrastructure',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+    )
+    op.create_table(
+        'solutions',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+    )
+    op.create_table(
+        'types_infrastructure',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+    )
+    op.create_table(
+        'types_offre',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+    )
+
+def downgrade():
+    op.drop_table('types_offre')
+    op.drop_table('types_infrastructure')
+    op.drop_table('solutions')
+    op.drop_table('modules_infrastructure')
+    op.drop_table('machine_definitions')
+    op.drop_table('inventories')
+    op.drop_table('infrastructures')
+    op.drop_table('groupes')
+    op.drop_table('offres')
+    op.drop_table('projets')
+    op.drop_table('users')
+    op.drop_table('organisations')

--- a/Bibind/op_bootstrap/app/config/database.py
+++ b/Bibind/op_bootstrap/app/config/database.py
@@ -1,0 +1,32 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.settings import settings
+
+
+def _build_db_url() -> str:
+    """Construct the database URL from environment variables."""
+    if settings.database_url:
+        return settings.database_url
+    user = os.getenv("POSTGRES_USER", "postgres")
+    password = os.getenv("POSTGRES_PASSWORD", "postgres")
+    host = os.getenv("POSTGRES_HOST", "localhost")
+    port = os.getenv("POSTGRES_PORT", "5432")
+    db = os.getenv("POSTGRES_DB", "postgres")
+    return f"postgresql://{user}:{password}@{host}:{port}/{db}"
+
+
+SQLALCHEMY_DATABASE_URL = _build_db_url()
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db():
+    """Yield a database session."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/Bibind/op_bootstrap/app/crud/__init__.py
+++ b/Bibind/op_bootstrap/app/crud/__init__.py
@@ -1,0 +1,43 @@
+from .base import CRUDBase
+from app.models import (
+    User,
+    Organisation,
+    Projet,
+    Offre,
+    Groupe,
+    Infrastructure,
+    Inventory,
+    MachineDefinition,
+    ModuleInfrastructure,
+    Solution,
+    TypeInfrastructure,
+    TypeOffre,
+)
+
+user = CRUDBase(User)
+organisation = CRUDBase(Organisation)
+projet = CRUDBase(Projet)
+offre = CRUDBase(Offre)
+groupe = CRUDBase(Groupe)
+infrastructure = CRUDBase(Infrastructure)
+inventory = CRUDBase(Inventory)
+machine_definition = CRUDBase(MachineDefinition)
+module_infrastructure = CRUDBase(ModuleInfrastructure)
+solution = CRUDBase(Solution)
+type_infrastructure = CRUDBase(TypeInfrastructure)
+type_offre = CRUDBase(TypeOffre)
+
+__all__ = [
+    "user",
+    "organisation",
+    "projet",
+    "offre",
+    "groupe",
+    "infrastructure",
+    "inventory",
+    "machine_definition",
+    "module_infrastructure",
+    "solution",
+    "type_infrastructure",
+    "type_offre",
+]

--- a/Bibind/op_bootstrap/app/crud/base.py
+++ b/Bibind/op_bootstrap/app/crud/base.py
@@ -1,4 +1,28 @@
-"""CRUD placeholder."""
+"""Generic CRUD utilities."""
+from typing import Generic, List, Optional, Type, TypeVar
 
-def create(obj):
-    return obj
+from sqlalchemy.orm import Session
+
+from app.models.base import Base
+
+ModelType = TypeVar("ModelType", bound=Base)
+
+
+class CRUDBase(Generic[ModelType]):
+    """Provide basic CRUD operations for a SQLAlchemy model."""
+
+    def __init__(self, model: Type[ModelType]):
+        self.model = model
+
+    def get(self, db: Session, id: int) -> Optional[ModelType]:
+        return db.query(self.model).filter(self.model.id == id).first()
+
+    def get_multi(self, db: Session, skip: int = 0, limit: int = 100) -> List[ModelType]:
+        return db.query(self.model).offset(skip).limit(limit).all()
+
+    def create(self, db: Session, obj_in: dict) -> ModelType:
+        db_obj = self.model(**obj_in)
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj

--- a/Bibind/op_bootstrap/app/crud/groupe.py
+++ b/Bibind/op_bootstrap/app/crud/groupe.py
@@ -1,4 +1,10 @@
-"""CRUD placeholder."""
+"""CRUD operations for Groupe."""
 
-def create(obj):
-    return obj
+from app.models.groupe import Groupe
+from .base import CRUDBase
+
+crud_groupe = CRUDBase(Groupe)
+
+get = crud_groupe.get
+get_multi = crud_groupe.get_multi
+create = crud_groupe.create

--- a/Bibind/op_bootstrap/app/crud/infrastructure.py
+++ b/Bibind/op_bootstrap/app/crud/infrastructure.py
@@ -1,4 +1,10 @@
-"""CRUD placeholder."""
+"""CRUD operations for Infrastructure."""
 
-def create(obj):
-    return obj
+from app.models.infrastructure import Infrastructure
+from .base import CRUDBase
+
+crud_infrastructure = CRUDBase(Infrastructure)
+
+get = crud_infrastructure.get
+get_multi = crud_infrastructure.get_multi
+create = crud_infrastructure.create

--- a/Bibind/op_bootstrap/app/crud/inventory.py
+++ b/Bibind/op_bootstrap/app/crud/inventory.py
@@ -1,0 +1,10 @@
+"""CRUD operations for Inventory."""
+
+from app.models.inventory import Inventory
+from .base import CRUDBase
+
+crud_inventory = CRUDBase(Inventory)
+
+get = crud_inventory.get
+get_multi = crud_inventory.get_multi
+create = crud_inventory.create

--- a/Bibind/op_bootstrap/app/crud/machine_definition.py
+++ b/Bibind/op_bootstrap/app/crud/machine_definition.py
@@ -1,0 +1,10 @@
+"""CRUD operations for MachineDefinition."""
+
+from app.models.machine_definition import MachineDefinition
+from .base import CRUDBase
+
+crud_machine_definition = CRUDBase(MachineDefinition)
+
+get = crud_machine_definition.get
+get_multi = crud_machine_definition.get_multi
+create = crud_machine_definition.create

--- a/Bibind/op_bootstrap/app/crud/module_infrastructure.py
+++ b/Bibind/op_bootstrap/app/crud/module_infrastructure.py
@@ -1,0 +1,10 @@
+"""CRUD operations for ModuleInfrastructure."""
+
+from app.models.module_infrastructure import ModuleInfrastructure
+from .base import CRUDBase
+
+crud_module_infrastructure = CRUDBase(ModuleInfrastructure)
+
+get = crud_module_infrastructure.get
+get_multi = crud_module_infrastructure.get_multi
+create = crud_module_infrastructure.create

--- a/Bibind/op_bootstrap/app/crud/offre.py
+++ b/Bibind/op_bootstrap/app/crud/offre.py
@@ -1,4 +1,10 @@
-"""CRUD placeholder."""
+"""CRUD operations for Offre."""
 
-def create(obj):
-    return obj
+from app.models.offre import Offre
+from .base import CRUDBase
+
+crud_offre = CRUDBase(Offre)
+
+get = crud_offre.get
+get_multi = crud_offre.get_multi
+create = crud_offre.create

--- a/Bibind/op_bootstrap/app/crud/organisation.py
+++ b/Bibind/op_bootstrap/app/crud/organisation.py
@@ -1,4 +1,10 @@
-"""CRUD placeholder."""
+"""CRUD operations for Organisation."""
 
-def create(obj):
-    return obj
+from app.models.organisation import Organisation
+from .base import CRUDBase
+
+crud_organisation = CRUDBase(Organisation)
+
+get = crud_organisation.get
+get_multi = crud_organisation.get_multi
+create = crud_organisation.create

--- a/Bibind/op_bootstrap/app/crud/projet.py
+++ b/Bibind/op_bootstrap/app/crud/projet.py
@@ -1,4 +1,10 @@
-"""CRUD placeholder."""
+"""CRUD operations for Projet."""
 
-def create(obj):
-    return obj
+from app.models.projet import Projet
+from .base import CRUDBase
+
+crud_projet = CRUDBase(Projet)
+
+get = crud_projet.get
+get_multi = crud_projet.get_multi
+create = crud_projet.create

--- a/Bibind/op_bootstrap/app/crud/solution.py
+++ b/Bibind/op_bootstrap/app/crud/solution.py
@@ -1,4 +1,10 @@
-"""CRUD placeholder."""
+"""CRUD operations for Solution."""
 
-def create(obj):
-    return obj
+from app.models.solution import Solution
+from .base import CRUDBase
+
+crud_solution = CRUDBase(Solution)
+
+get = crud_solution.get
+get_multi = crud_solution.get_multi
+create = crud_solution.create

--- a/Bibind/op_bootstrap/app/crud/type_infrastructure.py
+++ b/Bibind/op_bootstrap/app/crud/type_infrastructure.py
@@ -1,4 +1,10 @@
-"""CRUD placeholder."""
+"""CRUD operations for TypeInfrastructure."""
 
-def create(obj):
-    return obj
+from app.models.type_infrastructure import TypeInfrastructure
+from .base import CRUDBase
+
+crud_type_infrastructure = CRUDBase(TypeInfrastructure)
+
+get = crud_type_infrastructure.get
+get_multi = crud_type_infrastructure.get_multi
+create = crud_type_infrastructure.create

--- a/Bibind/op_bootstrap/app/crud/type_offre.py
+++ b/Bibind/op_bootstrap/app/crud/type_offre.py
@@ -1,4 +1,10 @@
-"""CRUD placeholder."""
+"""CRUD operations for TypeOffre."""
 
-def create(obj):
-    return obj
+from app.models.type_offre import TypeOffre
+from .base import CRUDBase
+
+crud_type_offre = CRUDBase(TypeOffre)
+
+get = crud_type_offre.get
+get_multi = crud_type_offre.get_multi
+create = crud_type_offre.create

--- a/Bibind/op_bootstrap/app/crud/user.py
+++ b/Bibind/op_bootstrap/app/crud/user.py
@@ -1,4 +1,12 @@
-"""CRUD placeholder."""
+"""CRUD operations for User."""
 
-def create(obj):
-    return obj
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from .base import CRUDBase
+
+crud_user = CRUDBase(User)
+
+get = crud_user.get
+get_multi = crud_user.get_multi
+create = crud_user.create

--- a/Bibind/op_bootstrap/app/models/__init__.py
+++ b/Bibind/op_bootstrap/app/models/__init__.py
@@ -1,0 +1,29 @@
+from .base import Base
+from .user import User
+from .organisation import Organisation
+from .projet import Projet
+from .offre import Offre
+from .groupe import Groupe
+from .infrastructure import Infrastructure
+from .inventory import Inventory
+from .machine_definition import MachineDefinition
+from .module_infrastructure import ModuleInfrastructure
+from .solution import Solution
+from .type_infrastructure import TypeInfrastructure
+from .type_offre import TypeOffre
+
+__all__ = [
+    "Base",
+    "User",
+    "Organisation",
+    "Projet",
+    "Offre",
+    "Groupe",
+    "Infrastructure",
+    "Inventory",
+    "MachineDefinition",
+    "ModuleInfrastructure",
+    "Solution",
+    "TypeInfrastructure",
+    "TypeOffre",
+]

--- a/Bibind/op_bootstrap/app/models/groupe.py
+++ b/Bibind/op_bootstrap/app/models/groupe.py
@@ -1,8 +1,12 @@
-"""ORM model placeholder."""
+"""Groupe ORM model."""
+
+from sqlalchemy import Column, Integer, String
 
 from .base import Base
-from sqlalchemy import Column, Integer
 
-class Model(Base):
-    __tablename__ = "placeholder"
-    id = Column(Integer, primary_key=True)
+
+class Groupe(Base):
+    __tablename__ = "groupes"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)

--- a/Bibind/op_bootstrap/app/models/infrastructure.py
+++ b/Bibind/op_bootstrap/app/models/infrastructure.py
@@ -1,8 +1,12 @@
-"""ORM model placeholder."""
+"""Infrastructure ORM model."""
+
+from sqlalchemy import Column, Integer, String
 
 from .base import Base
-from sqlalchemy import Column, Integer
 
-class Model(Base):
-    __tablename__ = "placeholder"
-    id = Column(Integer, primary_key=True)
+
+class Infrastructure(Base):
+    __tablename__ = "infrastructures"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)

--- a/Bibind/op_bootstrap/app/models/inventory.py
+++ b/Bibind/op_bootstrap/app/models/inventory.py
@@ -1,8 +1,12 @@
-"""ORM model placeholder."""
+"""Inventory ORM model."""
+
+from sqlalchemy import Column, Integer, String
 
 from .base import Base
-from sqlalchemy import Column, Integer
 
-class Model(Base):
-    __tablename__ = "placeholder"
-    id = Column(Integer, primary_key=True)
+
+class Inventory(Base):
+    __tablename__ = "inventories"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)

--- a/Bibind/op_bootstrap/app/models/machine_definition.py
+++ b/Bibind/op_bootstrap/app/models/machine_definition.py
@@ -1,8 +1,12 @@
-"""ORM model placeholder."""
+"""MachineDefinition ORM model."""
+
+from sqlalchemy import Column, Integer, String
 
 from .base import Base
-from sqlalchemy import Column, Integer
 
-class Model(Base):
-    __tablename__ = "placeholder"
-    id = Column(Integer, primary_key=True)
+
+class MachineDefinition(Base):
+    __tablename__ = "machine_definitions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)

--- a/Bibind/op_bootstrap/app/models/module_infrastructure.py
+++ b/Bibind/op_bootstrap/app/models/module_infrastructure.py
@@ -1,8 +1,12 @@
-"""ORM model placeholder."""
+"""ModuleInfrastructure ORM model."""
+
+from sqlalchemy import Column, Integer, String
 
 from .base import Base
-from sqlalchemy import Column, Integer
 
-class Model(Base):
-    __tablename__ = "placeholder"
-    id = Column(Integer, primary_key=True)
+
+class ModuleInfrastructure(Base):
+    __tablename__ = "modules_infrastructure"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)

--- a/Bibind/op_bootstrap/app/models/offre.py
+++ b/Bibind/op_bootstrap/app/models/offre.py
@@ -1,8 +1,17 @@
-"""ORM model placeholder."""
+"""Offre ORM model."""
+
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
 
 from .base import Base
-from sqlalchemy import Column, Integer
 
-class Model(Base):
-    __tablename__ = "placeholder"
-    id = Column(Integer, primary_key=True)
+
+class Offre(Base):
+    __tablename__ = "offres"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    description = Column(String)
+    projet_id = Column(Integer, ForeignKey("projets.id"))
+
+    projet = relationship("Projet", back_populates="offres")

--- a/Bibind/op_bootstrap/app/models/organisation.py
+++ b/Bibind/op_bootstrap/app/models/organisation.py
@@ -1,8 +1,16 @@
-"""ORM model placeholder."""
+"""Organisation ORM model."""
+
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
 
 from .base import Base
-from sqlalchemy import Column, Integer
 
-class Model(Base):
-    __tablename__ = "placeholder"
-    id = Column(Integer, primary_key=True)
+
+class Organisation(Base):
+    __tablename__ = "organisations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+
+    users = relationship("User", back_populates="organisation")
+    projets = relationship("Projet", back_populates="organisation")

--- a/Bibind/op_bootstrap/app/models/projet.py
+++ b/Bibind/op_bootstrap/app/models/projet.py
@@ -1,8 +1,17 @@
-"""ORM model placeholder."""
+"""Projet ORM model."""
+
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
 
 from .base import Base
-from sqlalchemy import Column, Integer
 
-class Model(Base):
-    __tablename__ = "placeholder"
-    id = Column(Integer, primary_key=True)
+
+class Projet(Base):
+    __tablename__ = "projets"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    organisation_id = Column(Integer, ForeignKey("organisations.id"))
+
+    organisation = relationship("Organisation", back_populates="projets")
+    offres = relationship("Offre", back_populates="projet")

--- a/Bibind/op_bootstrap/app/models/solution.py
+++ b/Bibind/op_bootstrap/app/models/solution.py
@@ -1,8 +1,12 @@
-"""ORM model placeholder."""
+"""Solution ORM model."""
+
+from sqlalchemy import Column, Integer, String
 
 from .base import Base
-from sqlalchemy import Column, Integer
 
-class Model(Base):
-    __tablename__ = "placeholder"
-    id = Column(Integer, primary_key=True)
+
+class Solution(Base):
+    __tablename__ = "solutions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)

--- a/Bibind/op_bootstrap/app/models/type_infrastructure.py
+++ b/Bibind/op_bootstrap/app/models/type_infrastructure.py
@@ -1,8 +1,12 @@
-"""ORM model placeholder."""
+"""TypeInfrastructure ORM model."""
+
+from sqlalchemy import Column, Integer, String
 
 from .base import Base
-from sqlalchemy import Column, Integer
 
-class Model(Base):
-    __tablename__ = "placeholder"
-    id = Column(Integer, primary_key=True)
+
+class TypeInfrastructure(Base):
+    __tablename__ = "types_infrastructure"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)

--- a/Bibind/op_bootstrap/app/models/type_offre.py
+++ b/Bibind/op_bootstrap/app/models/type_offre.py
@@ -1,8 +1,12 @@
-"""ORM model placeholder."""
+"""TypeOffre ORM model."""
+
+from sqlalchemy import Column, Integer, String
 
 from .base import Base
-from sqlalchemy import Column, Integer
 
-class Model(Base):
-    __tablename__ = "placeholder"
-    id = Column(Integer, primary_key=True)
+
+class TypeOffre(Base):
+    __tablename__ = "types_offre"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)

--- a/Bibind/op_bootstrap/app/models/user.py
+++ b/Bibind/op_bootstrap/app/models/user.py
@@ -1,8 +1,18 @@
-"""ORM model placeholder."""
+"""User ORM model."""
+
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
 
 from .base import Base
-from sqlalchemy import Column, Integer
 
-class Model(Base):
-    __tablename__ = "placeholder"
-    id = Column(Integer, primary_key=True)
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    is_active = Column(Boolean, default=True)
+    organisation_id = Column(Integer, ForeignKey("organisations.id"))
+
+    organisation = relationship("Organisation", back_populates="users")


### PR DESCRIPTION
## Summary
- add SQLAlchemy database configuration
- flesh out ORM models for core entities
- implement generic CRUD utilities and instances
- set up Alembic with initial migration for PostgreSQL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688b7e54f6e8832580da17d37a662558