### PR TITLE
Implement all API routes

### DIFF
--- a/Bibind/op_bootstrap/app/routes/auth.py
+++ b/Bibind/op_bootstrap/app/routes/auth.py
@@ -1,8 +1,44 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Authentication routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.schemas.auth import LoginRequest, Token, RefreshToken, Permissions
+from app.schemas.user import User
+from app.services import auth_service
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/login", response_model=Token)
+async def login(credentials: LoginRequest) -> JSONResponse:
+    token = await auth_service.login(credentials)
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
+        )
+    return JSONResponse(status_code=status.HTTP_200_OK, content=token.dict())
+
+
+@router.get("/me", response_model=User)
+async def me(user: User = Depends(auth_service.get_current_user)) -> User:
+    return user
+
+
+@router.post("/refresh", response_model=Token)
+async def refresh(token: RefreshToken) -> JSONResponse:
+    new_token = await auth_service.refresh_token(token)
+    return JSONResponse(status_code=status.HTTP_200_OK, content=new_token.dict())
+
+
+@router.post("/logout")
+async def logout() -> JSONResponse:
+    await auth_service.logout()
+    return JSONResponse(
+        status_code=status.HTTP_200_OK, content={"detail": "logged out"}
+    )
+
+
+@router.get("/permissions", response_model=Permissions)
+async def permissions() -> Permissions:
+    return await auth_service.get_permissions()

--- a/Bibind/op_bootstrap/app/routes/catalogues/type_infrastructure.py
+++ b/Bibind/op_bootstrap/app/routes/catalogues/type_infrastructure.py
@@ -1,8 +1,48 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Type infrastructure catalogue routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.schemas.type_infrastructure import TypeInfrastructure, TypeInfrastructureCreate
+from app.services import catalogue_service
+
+router = APIRouter(prefix="/catalogues/type-infrastructure", tags=["catalogues"])
+
+
+@router.get("/", response_model=list[TypeInfrastructure])
+async def list_types() -> list[TypeInfrastructure]:
+    return await catalogue_service.list_type_infrastructure()
+
+
+@router.post(
+    "/", response_model=TypeInfrastructure, status_code=status.HTTP_201_CREATED
+)
+async def create_type(payload: TypeInfrastructureCreate) -> JSONResponse:
+    obj = await catalogue_service.create_type_infrastructure(payload)
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=obj.dict())
+
+
+@router.get("/{id}", response_model=TypeInfrastructure)
+async def get_type(id: int) -> TypeInfrastructure:
+    obj = await catalogue_service.get_type_infrastructure(id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Type not found")
+    return obj
+
+
+@router.put("/{id}", response_model=TypeInfrastructure)
+async def update_type(id: int, payload: TypeInfrastructureCreate) -> TypeInfrastructure:
+    obj = await catalogue_service.update_type_infrastructure(id, payload)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Type not found")
+    return obj
+
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_type(id: int) -> JSONResponse:
+    success = await catalogue_service.delete_type_infrastructure(id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Type not found")
+    return JSONResponse(
+        status_code=status.HTTP_204_NO_CONTENT, content={"detail": "deleted"}
+    )

--- a/Bibind/op_bootstrap/app/routes/catalogues/type_offre.py
+++ b/Bibind/op_bootstrap/app/routes/catalogues/type_offre.py
@@ -1,8 +1,46 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Type offre catalogue routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.schemas.type_offre import TypeOffre, TypeOffreCreate
+from app.services import catalogue_service
+
+router = APIRouter(prefix="/catalogues/type-offre", tags=["catalogues"])
+
+
+@router.get("/", response_model=list[TypeOffre])
+async def list_types() -> list[TypeOffre]:
+    return await catalogue_service.list_type_offre()
+
+
+@router.post("/", response_model=TypeOffre, status_code=status.HTTP_201_CREATED)
+async def create_type(payload: TypeOffreCreate) -> JSONResponse:
+    obj = await catalogue_service.create_type_offre(payload)
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=obj.dict())
+
+
+@router.get("/{id}", response_model=TypeOffre)
+async def get_type(id: int) -> TypeOffre:
+    obj = await catalogue_service.get_type_offre(id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Type not found")
+    return obj
+
+
+@router.put("/{id}", response_model=TypeOffre)
+async def update_type(id: int, payload: TypeOffreCreate) -> TypeOffre:
+    obj = await catalogue_service.update_type_offre(id, payload)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Type not found")
+    return obj
+
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_type(id: int) -> JSONResponse:
+    success = await catalogue_service.delete_type_offre(id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Type not found")
+    return JSONResponse(
+        status_code=status.HTTP_204_NO_CONTENT, content={"detail": "deleted"}
+    )

--- a/Bibind/op_bootstrap/app/routes/groupes.py
+++ b/Bibind/op_bootstrap/app/routes/groupes.py
@@ -1,8 +1,46 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Groupe routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.schemas.groupe import Groupe, GroupeCreate
+from app.services import groupe_service
+
+router = APIRouter(prefix="/groupes", tags=["groupes"])
+
+
+@router.get("/", response_model=list[Groupe])
+async def list_groupes() -> list[Groupe]:
+    return await groupe_service.list_groupes()
+
+
+@router.post("/", response_model=Groupe, status_code=status.HTTP_201_CREATED)
+async def create_groupe(payload: GroupeCreate) -> JSONResponse:
+    grp = await groupe_service.create_groupe(payload)
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=grp.dict())
+
+
+@router.get("/{id}", response_model=Groupe)
+async def get_groupe(id: int) -> Groupe:
+    grp = await groupe_service.get_groupe(id)
+    if not grp:
+        raise HTTPException(status_code=404, detail="Groupe not found")
+    return grp
+
+
+@router.put("/{id}", response_model=Groupe)
+async def update_groupe(id: int, payload: GroupeCreate) -> Groupe:
+    grp = await groupe_service.update_groupe(id, payload)
+    if not grp:
+        raise HTTPException(status_code=404, detail="Groupe not found")
+    return grp
+
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_groupe(id: int) -> JSONResponse:
+    success = await groupe_service.delete_groupe(id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Groupe not found")
+    return JSONResponse(
+        status_code=status.HTTP_204_NO_CONTENT, content={"detail": "deleted"}
+    )

--- a/Bibind/op_bootstrap/app/routes/infrastructures/infrastructure.py
+++ b/Bibind/op_bootstrap/app/routes/infrastructures/infrastructure.py
@@ -1,8 +1,48 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Infrastructure routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.schemas.infrastructure import Infrastructure, InfrastructureCreate
+from app.services import infrastructure_service
+
+router = APIRouter(prefix="/infrastructures", tags=["infrastructures"])
+
+
+@router.get("/", response_model=list[Infrastructure])
+async def list_infrastructures() -> list[Infrastructure]:
+    return await infrastructure_service.list_infrastructures()
+
+
+@router.post("/", response_model=Infrastructure, status_code=status.HTTP_201_CREATED)
+async def create_infrastructure(payload: InfrastructureCreate) -> JSONResponse:
+    infra = await infrastructure_service.create_infrastructure(payload)
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=infra.dict())
+
+
+@router.get("/{id}", response_model=Infrastructure)
+async def get_infrastructure(id: int) -> Infrastructure:
+    infra = await infrastructure_service.get_infrastructure(id)
+    if not infra:
+        raise HTTPException(status_code=404, detail="Infrastructure not found")
+    return infra
+
+
+@router.put("/{id}", response_model=Infrastructure)
+async def update_infrastructure(
+    id: int, payload: InfrastructureCreate
+) -> Infrastructure:
+    infra = await infrastructure_service.update_infrastructure(id, payload)
+    if not infra:
+        raise HTTPException(status_code=404, detail="Infrastructure not found")
+    return infra
+
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_infrastructure(id: int) -> JSONResponse:
+    success = await infrastructure_service.delete_infrastructure(id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Infrastructure not found")
+    return JSONResponse(
+        status_code=status.HTTP_204_NO_CONTENT, content={"detail": "deleted"}
+    )

--- a/Bibind/op_bootstrap/app/routes/infrastructures/inventory.py
+++ b/Bibind/op_bootstrap/app/routes/infrastructures/inventory.py
@@ -1,8 +1,25 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Infrastructure inventory routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.schemas.infrastructure import Inventory, InventoryExport
+from app.services import inventory_service
+
+router = APIRouter(prefix="/infrastructures", tags=["infrastructures"])
+
+
+@router.get("/{id}/inventory", response_model=Inventory)
+async def get_inventory(id: int) -> Inventory:
+    return await inventory_service.get_inventory(id)
+
+
+@router.post("/{id}/inventory/export", response_model=InventoryExport)
+async def export_inventory(id: int) -> InventoryExport:
+    return await inventory_service.export_inventory(id)
+
+
+@router.get("/{id}/tfstate")
+async def get_tfstate(id: int) -> JSONResponse:
+    data = await inventory_service.get_tfstate(id)
+    return JSONResponse(status_code=status.HTTP_200_OK, content=data)

--- a/Bibind/op_bootstrap/app/routes/infrastructures/monitoring.py
+++ b/Bibind/op_bootstrap/app/routes/infrastructures/monitoring.py
@@ -1,8 +1,26 @@
-"""API routes."""
+"""Monitoring routes."""
+
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
 
-router = APIRouter()
+from app.services import monitoring_service
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+router = APIRouter(tags=["monitoring"])  # prefix added in paths
+
+
+@router.get("/monitoring/{infra_id}/status")
+async def status(infra_id: int) -> JSONResponse:
+    data = await monitoring_service.get_status(infra_id)
+    return JSONResponse(status_code=200, content=data)
+
+
+@router.get("/monitoring/{infra_id}/logs")
+async def logs(infra_id: int) -> JSONResponse:
+    data = await monitoring_service.get_logs(infra_id)
+    return JSONResponse(status_code=200, content={"logs": data})
+
+
+@router.get("/monitoring/alerts")
+async def alerts() -> JSONResponse:
+    data = await monitoring_service.get_alerts()
+    return JSONResponse(status_code=200, content={"alerts": data})

--- a/Bibind/op_bootstrap/app/routes/offres/offre.py
+++ b/Bibind/op_bootstrap/app/routes/offres/offre.py
@@ -1,8 +1,46 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Offres routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.schemas.offre import Offre, OffreCreate
+from app.services import offre_service
+
+router = APIRouter(prefix="/offres", tags=["offres"])
+
+
+@router.get("/", response_model=list[Offre])
+async def list_offres() -> list[Offre]:
+    return await offre_service.list_offres()
+
+
+@router.post("/", response_model=Offre, status_code=status.HTTP_201_CREATED)
+async def create_offre(payload: OffreCreate) -> JSONResponse:
+    off = await offre_service.create_offre(payload)
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=off.dict())
+
+
+@router.get("/{id}", response_model=Offre)
+async def get_offre(id: int) -> Offre:
+    off = await offre_service.get_offre(id)
+    if not off:
+        raise HTTPException(status_code=404, detail="Offre not found")
+    return off
+
+
+@router.put("/{id}", response_model=Offre)
+async def update_offre(id: int, payload: OffreCreate) -> Offre:
+    off = await offre_service.update_offre(id, payload)
+    if not off:
+        raise HTTPException(status_code=404, detail="Offre not found")
+    return off
+
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_offre(id: int) -> JSONResponse:
+    success = await offre_service.delete_offre(id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Offre not found")
+    return JSONResponse(
+        status_code=status.HTTP_204_NO_CONTENT, content={"detail": "deleted"}
+    )

--- a/Bibind/op_bootstrap/app/routes/offres/projet.py
+++ b/Bibind/op_bootstrap/app/routes/offres/projet.py
@@ -1,8 +1,46 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Projet routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.schemas.projet import Projet, ProjetCreate
+from app.services import project_service
+
+router = APIRouter(prefix="/projets", tags=["projets"])
+
+
+@router.get("/", response_model=list[Projet])
+async def list_projets() -> list[Projet]:
+    return await project_service.list_projets()
+
+
+@router.post("/", response_model=Projet, status_code=status.HTTP_201_CREATED)
+async def create_projet(payload: ProjetCreate) -> JSONResponse:
+    proj = await project_service.create_projet(payload)
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=proj.dict())
+
+
+@router.get("/{id}", response_model=Projet)
+async def get_projet(id: int) -> Projet:
+    proj = await project_service.get_projet(id)
+    if not proj:
+        raise HTTPException(status_code=404, detail="Projet not found")
+    return proj
+
+
+@router.put("/{id}", response_model=Projet)
+async def update_projet(id: int, payload: ProjetCreate) -> Projet:
+    proj = await project_service.update_projet(id, payload)
+    if not proj:
+        raise HTTPException(status_code=404, detail="Projet not found")
+    return proj
+
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_projet(id: int) -> JSONResponse:
+    success = await project_service.delete_projet(id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Projet not found")
+    return JSONResponse(
+        status_code=status.HTTP_204_NO_CONTENT, content={"detail": "deleted"}
+    )

--- a/Bibind/op_bootstrap/app/routes/offres/solution.py
+++ b/Bibind/op_bootstrap/app/routes/offres/solution.py
@@ -1,8 +1,46 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Solution routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.schemas.solution import Solution, SolutionCreate
+from app.services import solution_service
+
+router = APIRouter(prefix="/solutions", tags=["solutions"])
+
+
+@router.get("/", response_model=list[Solution])
+async def list_solutions() -> list[Solution]:
+    return await solution_service.list_solutions()
+
+
+@router.post("/", response_model=Solution, status_code=status.HTTP_201_CREATED)
+async def create_solution(payload: SolutionCreate) -> JSONResponse:
+    sol = await solution_service.create_solution(payload)
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=sol.dict())
+
+
+@router.get("/{id}", response_model=Solution)
+async def get_solution(id: int) -> Solution:
+    sol = await solution_service.get_solution(id)
+    if not sol:
+        raise HTTPException(status_code=404, detail="Solution not found")
+    return sol
+
+
+@router.put("/{id}", response_model=Solution)
+async def update_solution(id: int, payload: SolutionCreate) -> Solution:
+    sol = await solution_service.update_solution(id, payload)
+    if not sol:
+        raise HTTPException(status_code=404, detail="Solution not found")
+    return sol
+
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_solution(id: int) -> JSONResponse:
+    success = await solution_service.delete_solution(id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Solution not found")
+    return JSONResponse(
+        status_code=status.HTTP_204_NO_CONTENT, content={"detail": "deleted"}
+    )

--- a/Bibind/op_bootstrap/app/routes/orchestrateur/events.py
+++ b/Bibind/op_bootstrap/app/routes/orchestrateur/events.py
@@ -1,8 +1,26 @@
-"""API routes."""
+"""Events mapping routes."""
+
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
 
-router = APIRouter()
+from app.services import orchestrator_service
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+router = APIRouter(prefix="/events", tags=["orchestrateur"])
+
+
+@router.get("/types")
+async def event_types() -> JSONResponse:
+    data = await orchestrator_service.event_types()
+    return JSONResponse(status_code=200, content={"types": data})
+
+
+@router.get("/mapping")
+async def event_mapping() -> JSONResponse:
+    data = await orchestrator_service.event_mapping()
+    return JSONResponse(status_code=200, content=data)
+
+
+@router.post("/test")
+async def test_event(payload: dict) -> JSONResponse:
+    result = await orchestrator_service.test_event(payload)
+    return JSONResponse(status_code=200, content={"result": result})

--- a/Bibind/op_bootstrap/app/routes/orchestrateur/langgraph.py
+++ b/Bibind/op_bootstrap/app/routes/orchestrateur/langgraph.py
@@ -1,8 +1,26 @@
-"""API routes."""
+"""Langgraph routes."""
+
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
 
-router = APIRouter()
+from app.services import orchestrator_service
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+router = APIRouter(prefix="/langgraph", tags=["orchestrateur"])
+
+
+@router.post("/execute/simple")
+async def execute_simple(payload: dict) -> JSONResponse:
+    data = await orchestrator_service.execute_langgraph_simple(payload)
+    return JSONResponse(status_code=200, content=data)
+
+
+@router.post("/execute/custom")
+async def execute_custom(payload: dict) -> JSONResponse:
+    data = await orchestrator_service.execute_langgraph_custom(payload)
+    return JSONResponse(status_code=200, content=data)
+
+
+@router.get("/status/{workflow_id}")
+async def get_status(workflow_id: int) -> JSONResponse:
+    data = await orchestrator_service.langgraph_status(workflow_id)
+    return JSONResponse(status_code=200, content=data)

--- a/Bibind/op_bootstrap/app/routes/orchestrateur/principal.py
+++ b/Bibind/op_bootstrap/app/routes/orchestrateur/principal.py
@@ -1,8 +1,22 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Orchestrateur principal routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.services import orchestrator_service
+
+router = APIRouter(prefix="/orchestrateur", tags=["orchestrateur"])
+
+
+@router.post("/trigger-offre")
+async def trigger_offre(payload: dict) -> JSONResponse:
+    result = await orchestrator_service.trigger_offre(payload)
+    return JSONResponse(
+        status_code=status.HTTP_202_ACCEPTED, content={"result": result}
+    )
+
+
+@router.get("/status/{id}")
+async def status(id: int) -> JSONResponse:
+    data = await orchestrator_service.get_status(id)
+    return JSONResponse(status_code=200, content=data)

--- a/Bibind/op_bootstrap/app/routes/orchestrateur/trigger.py
+++ b/Bibind/op_bootstrap/app/routes/orchestrateur/trigger.py
@@ -1,8 +1,22 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Trigger orchestrator routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.services import orchestrator_service
+
+router = APIRouter(prefix="/trigger", tags=["orchestrateur"])
+
+
+@router.post("/{so_name}")
+async def trigger_so(so_name: str, payload: dict) -> JSONResponse:
+    result = await orchestrator_service.trigger_so(so_name, payload)
+    return JSONResponse(
+        status_code=status.HTTP_202_ACCEPTED, content={"result": result}
+    )
+
+
+@router.get("/list")
+async def list_triggers() -> JSONResponse:
+    data = await orchestrator_service.list_triggers()
+    return JSONResponse(status_code=200, content={"triggers": data})

--- a/Bibind/op_bootstrap/app/routes/organisations.py
+++ b/Bibind/op_bootstrap/app/routes/organisations.py
@@ -1,8 +1,46 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Organisation routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.schemas.organisation import Organisation, OrganisationCreate
+from app.services import organisation_service
+
+router = APIRouter(prefix="/organisations", tags=["organisations"])
+
+
+@router.get("/", response_model=list[Organisation])
+async def list_organisations() -> list[Organisation]:
+    return await organisation_service.list_organisations()
+
+
+@router.post("/", response_model=Organisation, status_code=status.HTTP_201_CREATED)
+async def create_organisation(payload: OrganisationCreate) -> JSONResponse:
+    org = await organisation_service.create_organisation(payload)
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=org.dict())
+
+
+@router.get("/{id}", response_model=Organisation)
+async def get_organisation(id: int) -> Organisation:
+    org = await organisation_service.get_organisation(id)
+    if not org:
+        raise HTTPException(status_code=404, detail="Organisation not found")
+    return org
+
+
+@router.put("/{id}", response_model=Organisation)
+async def update_organisation(id: int, payload: OrganisationCreate) -> Organisation:
+    org = await organisation_service.update_organisation(id, payload)
+    if not org:
+        raise HTTPException(status_code=404, detail="Organisation not found")
+    return org
+
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_organisation(id: int) -> JSONResponse:
+    success = await organisation_service.delete_organisation(id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Organisation not found")
+    return JSONResponse(
+        status_code=status.HTTP_204_NO_CONTENT, content={"detail": "deleted"}
+    )

--- a/Bibind/op_bootstrap/app/routes/users.py
+++ b/Bibind/op_bootstrap/app/routes/users.py
@@ -1,8 +1,46 @@
-"""API routes."""
-from fastapi import APIRouter
+"""User routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.schemas.user import User, UserCreate
+from app.services import user_service
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.get("/", response_model=list[User])
+async def list_users() -> list[User]:
+    return await user_service.list_users()
+
+
+@router.post("/", response_model=User, status_code=status.HTTP_201_CREATED)
+async def create_user(payload: UserCreate) -> JSONResponse:
+    user = await user_service.create_user(payload)
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=user.dict())
+
+
+@router.get("/{user_id}", response_model=User)
+async def get_user(user_id: int) -> User:
+    user = await user_service.get_user(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.put("/{user_id}", response_model=User)
+async def update_user(user_id: int, payload: UserCreate) -> User:
+    user = await user_service.update_user(user_id, payload)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_user(user_id: int) -> JSONResponse:
+    success = await user_service.delete_user(user_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="User not found")
+    return JSONResponse(
+        status_code=status.HTTP_204_NO_CONTENT, content={"detail": "deleted"}
+    )

--- a/Bibind/op_bootstrap/app/routes/validation/human_validation.py
+++ b/Bibind/op_bootstrap/app/routes/validation/human_validation.py
@@ -1,8 +1,30 @@
-"""API routes."""
-from fastapi import APIRouter
+"""Human validation routes."""
 
-router = APIRouter()
+from fastapi import APIRouter, status, HTTPException
+from fastapi.responses import JSONResponse
 
-@router.get('/ping')
-async def ping() -> dict:
-    return {'pong': True}
+from app.services import validation_service
+
+router = APIRouter(prefix="/validation", tags=["validation"])
+
+
+@router.post("/approve/{event_id}")
+async def approve(event_id: int) -> JSONResponse:
+    ok = await validation_service.approve(event_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return JSONResponse(status_code=status.HTTP_200_OK, content={"detail": "approved"})
+
+
+@router.post("/reject/{event_id}")
+async def reject(event_id: int) -> JSONResponse:
+    ok = await validation_service.reject(event_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return JSONResponse(status_code=status.HTTP_200_OK, content={"detail": "rejected"})
+
+
+@router.get("/pending")
+async def pending() -> JSONResponse:
+    data = await validation_service.pending()
+    return JSONResponse(status_code=200, content={"events": data})

--- a/Bibind/op_bootstrap/app/schemas/groupe.py
+++ b/Bibind/op_bootstrap/app/schemas/groupe.py
@@ -1,6 +1,16 @@
-"""Pydantic schema placeholder."""
-
 from pydantic import BaseModel
 
-class Schema(BaseModel):
+
+class GroupeBase(BaseModel):
+    name: str
+
+
+class GroupeCreate(GroupeBase):
+    pass
+
+
+class Groupe(GroupeBase):
     id: int
+
+    class Config:
+        orm_mode = True

--- a/Bibind/op_bootstrap/app/schemas/infrastructure.py
+++ b/Bibind/op_bootstrap/app/schemas/infrastructure.py
@@ -1,6 +1,26 @@
-"""Pydantic schema placeholder."""
-
 from pydantic import BaseModel
 
-class Schema(BaseModel):
+
+class InfrastructureBase(BaseModel):
+    name: str
+
+
+class InfrastructureCreate(InfrastructureBase):
+    pass
+
+
+class Infrastructure(InfrastructureBase):
     id: int
+
+    class Config:
+        orm_mode = True
+
+
+class Inventory(BaseModel):
+    id: int
+    name: str
+
+
+class InventoryExport(BaseModel):
+    infra_id: int
+    detail: str

--- a/Bibind/op_bootstrap/app/schemas/offre.py
+++ b/Bibind/op_bootstrap/app/schemas/offre.py
@@ -1,6 +1,17 @@
-"""Pydantic schema placeholder."""
-
 from pydantic import BaseModel
 
-class Schema(BaseModel):
+
+class OffreBase(BaseModel):
+    name: str
+
+
+class OffreCreate(OffreBase):
+    pass
+
+
+class Offre(OffreBase):
     id: int
+    description: str | None = None
+
+    class Config:
+        orm_mode = True

--- a/Bibind/op_bootstrap/app/schemas/organisation.py
+++ b/Bibind/op_bootstrap/app/schemas/organisation.py
@@ -1,6 +1,16 @@
-"""Pydantic schema placeholder."""
-
 from pydantic import BaseModel
 
-class Schema(BaseModel):
+
+class OrganisationBase(BaseModel):
+    name: str
+
+
+class OrganisationCreate(OrganisationBase):
+    pass
+
+
+class Organisation(OrganisationBase):
     id: int
+
+    class Config:
+        orm_mode = True

--- a/Bibind/op_bootstrap/app/schemas/projet.py
+++ b/Bibind/op_bootstrap/app/schemas/projet.py
@@ -1,6 +1,16 @@
-"""Pydantic schema placeholder."""
-
 from pydantic import BaseModel
 
-class Schema(BaseModel):
+
+class ProjetBase(BaseModel):
+    name: str
+
+
+class ProjetCreate(ProjetBase):
+    pass
+
+
+class Projet(ProjetBase):
     id: int
+
+    class Config:
+        orm_mode = True

--- a/Bibind/op_bootstrap/app/schemas/solution.py
+++ b/Bibind/op_bootstrap/app/schemas/solution.py
@@ -1,6 +1,16 @@
-"""Pydantic schema placeholder."""
-
 from pydantic import BaseModel
 
-class Schema(BaseModel):
+
+class SolutionBase(BaseModel):
+    name: str
+
+
+class SolutionCreate(SolutionBase):
+    pass
+
+
+class Solution(SolutionBase):
     id: int
+
+    class Config:
+        orm_mode = True

--- a/Bibind/op_bootstrap/app/schemas/type_infrastructure.py
+++ b/Bibind/op_bootstrap/app/schemas/type_infrastructure.py
@@ -1,6 +1,16 @@
-"""Pydantic schema placeholder."""
-
 from pydantic import BaseModel
 
-class Schema(BaseModel):
+
+class TypeInfrastructureBase(BaseModel):
+    name: str
+
+
+class TypeInfrastructureCreate(TypeInfrastructureBase):
+    pass
+
+
+class TypeInfrastructure(TypeInfrastructureBase):
     id: int
+
+    class Config:
+        orm_mode = True

--- a/Bibind/op_bootstrap/app/schemas/type_offre.py
+++ b/Bibind/op_bootstrap/app/schemas/type_offre.py
@@ -1,6 +1,16 @@
-"""Pydantic schema placeholder."""
-
 from pydantic import BaseModel
 
-class Schema(BaseModel):
+
+class TypeOffreBase(BaseModel):
+    name: str
+
+
+class TypeOffreCreate(TypeOffreBase):
+    pass
+
+
+class TypeOffre(TypeOffreBase):
     id: int
+
+    class Config:
+        orm_mode = True

--- a/Bibind/op_bootstrap/app/schemas/user.py
+++ b/Bibind/op_bootstrap/app/schemas/user.py
@@ -1,6 +1,17 @@
-"""Pydantic schema placeholder."""
+from pydantic import BaseModel, EmailStr
 
-from pydantic import BaseModel
 
-class Schema(BaseModel):
+class UserBase(BaseModel):
+    email: EmailStr
+
+
+class UserCreate(UserBase):
+    password: str
+
+
+class User(UserBase):
     id: int
+    is_active: bool = True
+
+    class Config:
+        orm_mode = True

--- a/Bibind/op_bootstrap/app/services/auth_service.py
+++ b/Bibind/op_bootstrap/app/services/auth_service.py
@@ -1,0 +1,27 @@
+from app.schemas.auth import LoginRequest, Token, RefreshToken, Permissions
+from app.schemas.user import User
+
+
+async def login(credentials: LoginRequest) -> Token:
+    """Return a fake JWT token."""
+    return Token(access_token="fake-token", token_type="bearer")
+
+
+async def get_current_user() -> User:
+    """Return a mock current user."""
+    return User(id=1, email="user@example.com", is_active=True)
+
+
+async def refresh_token(_: RefreshToken) -> Token:
+    """Return a refreshed token."""
+    return Token(access_token="refreshed-token", token_type="bearer")
+
+
+async def logout() -> bool:
+    """Mock logout action."""
+    return True
+
+
+async def get_permissions() -> Permissions:
+    """Return mock permissions."""
+    return Permissions(permissions=["read", "write"])

--- a/Bibind/op_bootstrap/app/services/catalogue_service.py
+++ b/Bibind/op_bootstrap/app/services/catalogue_service.py
@@ -1,0 +1,54 @@
+from app.schemas.type_infrastructure import TypeInfrastructure, TypeInfrastructureCreate
+from app.schemas.type_offre import TypeOffre, TypeOffreCreate
+
+
+async def list_type_infrastructure() -> list[TypeInfrastructure]:
+    return [TypeInfrastructure(id=1, name="VM")]
+
+
+async def create_type_infrastructure(
+    obj: TypeInfrastructureCreate,
+) -> TypeInfrastructure:
+    return TypeInfrastructure(id=1, name=obj.name)
+
+
+async def get_type_infrastructure(type_id: int) -> TypeInfrastructure | None:
+    if type_id == 1:
+        return TypeInfrastructure(id=1, name="VM")
+    return None
+
+
+async def update_type_infrastructure(
+    type_id: int, obj: TypeInfrastructureCreate
+) -> TypeInfrastructure | None:
+    if type_id == 1:
+        return TypeInfrastructure(id=1, name=obj.name)
+    return None
+
+
+async def delete_type_infrastructure(type_id: int) -> bool:
+    return type_id == 1
+
+
+async def list_type_offre() -> list[TypeOffre]:
+    return [TypeOffre(id=1, name="SaaS")]
+
+
+async def create_type_offre(obj: TypeOffreCreate) -> TypeOffre:
+    return TypeOffre(id=1, name=obj.name)
+
+
+async def get_type_offre(type_id: int) -> TypeOffre | None:
+    if type_id == 1:
+        return TypeOffre(id=1, name="SaaS")
+    return None
+
+
+async def update_type_offre(type_id: int, obj: TypeOffreCreate) -> TypeOffre | None:
+    if type_id == 1:
+        return TypeOffre(id=1, name=obj.name)
+    return None
+
+
+async def delete_type_offre(type_id: int) -> bool:
+    return type_id == 1

--- a/Bibind/op_bootstrap/app/services/groupe_service.py
+++ b/Bibind/op_bootstrap/app/services/groupe_service.py
@@ -1,0 +1,25 @@
+from app.schemas.groupe import Groupe, GroupeCreate
+
+
+async def list_groupes() -> list[Groupe]:
+    return [Groupe(id=1, name="Groupe1")]
+
+
+async def create_groupe(grp: GroupeCreate) -> Groupe:
+    return Groupe(id=1, name=grp.name)
+
+
+async def get_groupe(groupe_id: int) -> Groupe | None:
+    if groupe_id == 1:
+        return Groupe(id=1, name="Groupe1")
+    return None
+
+
+async def update_groupe(groupe_id: int, grp: GroupeCreate) -> Groupe | None:
+    if groupe_id == 1:
+        return Groupe(id=1, name=grp.name)
+    return None
+
+
+async def delete_groupe(groupe_id: int) -> bool:
+    return groupe_id == 1

--- a/Bibind/op_bootstrap/app/services/infrastructure_service.py
+++ b/Bibind/op_bootstrap/app/services/infrastructure_service.py
@@ -1,0 +1,27 @@
+from app.schemas.infrastructure import Infrastructure, InfrastructureCreate
+
+
+async def list_infrastructures() -> list[Infrastructure]:
+    return [Infrastructure(id=1, name="infra1")]
+
+
+async def create_infrastructure(obj: InfrastructureCreate) -> Infrastructure:
+    return Infrastructure(id=1, name=obj.name)
+
+
+async def get_infrastructure(infra_id: int) -> Infrastructure | None:
+    if infra_id == 1:
+        return Infrastructure(id=1, name="infra1")
+    return None
+
+
+async def update_infrastructure(
+    infra_id: int, obj: InfrastructureCreate
+) -> Infrastructure | None:
+    if infra_id == 1:
+        return Infrastructure(id=1, name=obj.name)
+    return None
+
+
+async def delete_infrastructure(infra_id: int) -> bool:
+    return infra_id == 1

--- a/Bibind/op_bootstrap/app/services/inventory_service.py
+++ b/Bibind/op_bootstrap/app/services/inventory_service.py
@@ -1,0 +1,13 @@
+from app.schemas.infrastructure import InventoryExport, Inventory
+
+
+async def get_inventory(infra_id: int) -> Inventory:
+    return Inventory(id=infra_id, name="inventory")
+
+
+async def export_inventory(infra_id: int) -> InventoryExport:
+    return InventoryExport(detail="exported", infra_id=infra_id)
+
+
+async def get_tfstate(infra_id: int) -> dict:
+    return {"id": infra_id, "tfstate": "{}"}

--- a/Bibind/op_bootstrap/app/services/monitoring_service.py
+++ b/Bibind/op_bootstrap/app/services/monitoring_service.py
@@ -1,0 +1,13 @@
+from typing import List
+
+
+async def get_status(infra_id: int) -> dict:
+    return {"infra_id": infra_id, "status": "ok"}
+
+
+async def get_logs(infra_id: int) -> List[str]:
+    return [f"log line for {infra_id}"]
+
+
+async def get_alerts() -> List[str]:
+    return ["alert1", "alert2"]

--- a/Bibind/op_bootstrap/app/services/offre_service.py
+++ b/Bibind/op_bootstrap/app/services/offre_service.py
@@ -1,0 +1,25 @@
+from app.schemas.offre import Offre, OffreCreate
+
+
+async def list_offres() -> list[Offre]:
+    return [Offre(id=1, name="Offre1")]
+
+
+async def create_offre(obj: OffreCreate) -> Offre:
+    return Offre(id=1, name=obj.name)
+
+
+async def get_offre(offre_id: int) -> Offre | None:
+    if offre_id == 1:
+        return Offre(id=1, name="Offre1")
+    return None
+
+
+async def update_offre(offre_id: int, obj: OffreCreate) -> Offre | None:
+    if offre_id == 1:
+        return Offre(id=1, name=obj.name)
+    return None
+
+
+async def delete_offre(offre_id: int) -> bool:
+    return offre_id == 1

--- a/Bibind/op_bootstrap/app/services/orchestrator_service.py
+++ b/Bibind/op_bootstrap/app/services/orchestrator_service.py
@@ -1,4 +1,53 @@
-"""Service placeholder."""
+from typing import List, Dict
 
-async def placeholder() -> str:
+
+async def trigger_offre(data: Dict) -> str:
+    return "triggered"
+
+
+async def get_status(task_id: int) -> Dict:
+    return {"task_id": task_id, "status": "running"}
+
+
+async def trigger_so(so_name: str, payload: Dict) -> str:
+    return f"triggered {so_name}"
+
+
+async def list_triggers() -> List[str]:
+    return ["so_conception", "so_planification"]
+
+
+async def event_types() -> List[str]:
+    return ["type1", "type2"]
+
+
+async def event_mapping() -> Dict[str, str]:
+    return {"type1": "so_conception"}
+
+
+async def test_event(data: Dict) -> str:
     return "ok"
+
+
+async def execute_langgraph_simple(data: Dict) -> Dict:
+    return {"workflow_id": 1}
+
+
+async def execute_langgraph_custom(data: Dict) -> Dict:
+    return {"workflow_id": 2}
+
+
+async def langgraph_status(workflow_id: int) -> Dict:
+    return {"workflow_id": workflow_id, "status": "done"}
+
+
+async def approve_event(event_id: int) -> bool:
+    return event_id == 1
+
+
+async def reject_event(event_id: int) -> bool:
+    return event_id == 1
+
+
+async def pending_events() -> List[int]:
+    return [1, 2]

--- a/Bibind/op_bootstrap/app/services/organisation_service.py
+++ b/Bibind/op_bootstrap/app/services/organisation_service.py
@@ -1,0 +1,27 @@
+from app.schemas.organisation import Organisation, OrganisationCreate
+
+
+async def list_organisations() -> list[Organisation]:
+    return [Organisation(id=1, name="Org1")]
+
+
+async def create_organisation(org: OrganisationCreate) -> Organisation:
+    return Organisation(id=1, name=org.name)
+
+
+async def get_organisation(org_id: int) -> Organisation | None:
+    if org_id == 1:
+        return Organisation(id=1, name="Org1")
+    return None
+
+
+async def update_organisation(
+    org_id: int, org: OrganisationCreate
+) -> Organisation | None:
+    if org_id == 1:
+        return Organisation(id=1, name=org.name)
+    return None
+
+
+async def delete_organisation(org_id: int) -> bool:
+    return org_id == 1

--- a/Bibind/op_bootstrap/app/services/project_service.py
+++ b/Bibind/op_bootstrap/app/services/project_service.py
@@ -1,4 +1,25 @@
-"""Service placeholder."""
+from app.schemas.projet import Projet, ProjetCreate
 
-async def placeholder() -> str:
-    return "ok"
+
+async def list_projets() -> list[Projet]:
+    return [Projet(id=1, name="Projet1")]
+
+
+async def create_projet(obj: ProjetCreate) -> Projet:
+    return Projet(id=1, name=obj.name)
+
+
+async def get_projet(projet_id: int) -> Projet | None:
+    if projet_id == 1:
+        return Projet(id=1, name="Projet1")
+    return None
+
+
+async def update_projet(projet_id: int, obj: ProjetCreate) -> Projet | None:
+    if projet_id == 1:
+        return Projet(id=1, name=obj.name)
+    return None
+
+
+async def delete_projet(projet_id: int) -> bool:
+    return projet_id == 1

--- a/Bibind/op_bootstrap/app/services/solution_service.py
+++ b/Bibind/op_bootstrap/app/services/solution_service.py
@@ -1,0 +1,25 @@
+from app.schemas.solution import Solution, SolutionCreate
+
+
+async def list_solutions() -> list[Solution]:
+    return [Solution(id=1, name="Solution1")]
+
+
+async def create_solution(obj: SolutionCreate) -> Solution:
+    return Solution(id=1, name=obj.name)
+
+
+async def get_solution(solution_id: int) -> Solution | None:
+    if solution_id == 1:
+        return Solution(id=1, name="Solution1")
+    return None
+
+
+async def update_solution(solution_id: int, obj: SolutionCreate) -> Solution | None:
+    if solution_id == 1:
+        return Solution(id=1, name=obj.name)
+    return None
+
+
+async def delete_solution(solution_id: int) -> bool:
+    return solution_id == 1

--- a/Bibind/op_bootstrap/app/services/user_service.py
+++ b/Bibind/op_bootstrap/app/services/user_service.py
@@ -1,4 +1,25 @@
-"""Service placeholder."""
+from app.schemas.user import User, UserCreate
 
-async def placeholder() -> str:
-    return "ok"
+
+async def list_users() -> list[User]:
+    return [User(id=1, email="user@example.com", is_active=True)]
+
+
+async def create_user(user: UserCreate) -> User:
+    return User(id=1, email=user.email, is_active=True)
+
+
+async def get_user(user_id: int) -> User | None:
+    if user_id == 1:
+        return User(id=1, email="user@example.com", is_active=True)
+    return None
+
+
+async def update_user(user_id: int, user: UserCreate) -> User | None:
+    if user_id == 1:
+        return User(id=1, email=user.email, is_active=True)
+    return None
+
+
+async def delete_user(user_id: int) -> bool:
+    return user_id == 1

--- a/Bibind/op_bootstrap/app/services/validation_service.py
+++ b/Bibind/op_bootstrap/app/services/validation_service.py
@@ -1,0 +1,13 @@
+from typing import List
+
+
+async def approve(event_id: int) -> bool:
+    return event_id == 1
+
+
+async def reject(event_id: int) -> bool:
+    return event_id == 1
+
+
+async def pending() -> List[int]:
+    return [1]

--- a/Bibind/op_bootstrap/main.py
+++ b/Bibind/op_bootstrap/main.py
@@ -1,11 +1,31 @@
 from fastapi import FastAPI
 
-from app.routes import auth
+from app.routes import auth, users, organisations, groupes
+from app.routes.catalogues import type_infrastructure, type_offre
+from app.routes.infrastructures import infrastructure, inventory, monitoring
+from app.routes.offres import offre, solution, projet
+from app.routes.orchestrateur import principal, trigger, events, langgraph
+from app.routes.validation import human_validation
 
 app = FastAPI(title="Operational Bootstrap")
 
-# Include sample router
 app.include_router(auth.router)
+app.include_router(users.router)
+app.include_router(organisations.router)
+app.include_router(groupes.router)
+app.include_router(type_infrastructure.router)
+app.include_router(type_offre.router)
+app.include_router(infrastructure.router)
+app.include_router(inventory.router)
+app.include_router(monitoring.router)
+app.include_router(offre.router)
+app.include_router(solution.router)
+app.include_router(projet.router)
+app.include_router(principal.router)
+app.include_router(trigger.router)
+app.include_router(events.router)
+app.include_router(langgraph.router)
+app.include_router(human_validation.router)
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- implement real route handlers across all modules
- add new stub services for each domain
- create simple Pydantic schemas
- register routers in main application

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_688b8330640c8325aa8f1a2d04f9722d