### PR TITLE
Implement Kafka utilities and mapping

### DIFF
--- a/Bibind/op_bootstrap/app/config/so_mapping.yaml
+++ b/Bibind/op_bootstrap/app/config/so_mapping.yaml
@@ -1,0 +1,7 @@
+topics:
+  so_conception: so_conception.tasks
+  so_organisation: so_organisation.tasks
+  so_planification: so_planification.tasks
+  so_realisation: so_realisation.tasks
+  so_qualite: so_qualite.tasks
+  so_release: so_release.deployment

--- a/Bibind/op_bootstrap/app/utils/kafka_consumer.py
+++ b/Bibind/op_bootstrap/app/utils/kafka_consumer.py
@@ -1,4 +1,42 @@
-"""Utility placeholder."""
+"""Generic Kafka consumer using aiokafka."""
 
-def dummy() -> None:
-    pass
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Callable
+
+from aiokafka import AIOKafkaConsumer
+
+
+async def _consume(
+    topics: list[str],
+    handler: Callable[[str, Any], None | asyncio.Future],
+    bootstrap_servers: str = "localhost:9092",
+) -> None:
+    consumer = AIOKafkaConsumer(
+        *topics,
+        bootstrap_servers=bootstrap_servers,
+        value_deserializer=lambda m: json.loads(m.decode("utf-8")),
+        group_id="op_bootstrap",
+        enable_auto_commit=True,
+    )
+    await consumer.start()
+    try:
+        async for msg in consumer:
+            result = handler(msg.topic, msg.value)
+            if asyncio.iscoroutine(result):
+                await result
+    finally:
+        await consumer.stop()
+
+
+def start_consumer(
+    topics: list[str],
+    handler: Callable[[str, Any], None | asyncio.Future],
+    loop: asyncio.AbstractEventLoop | None = None,
+    bootstrap_servers: str = "localhost:9092",
+) -> asyncio.Task:
+    """Start consumer in background task and return the task instance."""
+    loop = loop or asyncio.get_event_loop()
+    return loop.create_task(_consume(topics, handler, bootstrap_servers))

--- a/Bibind/op_bootstrap/app/utils/kafka_producer.py
+++ b/Bibind/op_bootstrap/app/utils/kafka_producer.py
@@ -1,4 +1,37 @@
-"""Utility placeholder."""
+"""Simple Kafka producer using aiokafka."""
 
-def dummy() -> None:
-    pass
+from __future__ import annotations
+
+import json
+from aiokafka import AIOKafkaProducer
+from typing import Any
+
+
+class KafkaProducer:
+    """Wrapper around :class:`AIOKafkaProducer` for JSON messages."""
+
+    def __init__(self, bootstrap_servers: str = "localhost:9092") -> None:
+        self._producer = AIOKafkaProducer(
+            bootstrap_servers=bootstrap_servers,
+            value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+        )
+        self._started = False
+
+    async def start(self) -> None:
+        if not self._started:
+            await self._producer.start()
+            self._started = True
+
+    async def stop(self) -> None:
+        if self._started:
+            await self._producer.stop()
+            self._started = False
+
+    async def send(self, topic: str, message: Any, key: str | None = None) -> None:
+        """Send a JSON serializable message to a topic."""
+        await self.start()
+        await self._producer.send_and_wait(
+            topic,
+            value=message,
+            key=key.encode("utf-8") if key else None,
+        )

--- a/Bibind/so_conception/kafka/consumer.py
+++ b/Bibind/so_conception/kafka/consumer.py
@@ -2,10 +2,27 @@
 
 from threading import Thread
 from kafka import KafkaConsumer
+from pathlib import Path
+import yaml
+
+SO_NAME = "so_conception"
 
 
-def _listen():
-    consumer = KafkaConsumer('conception-topic')
+def _get_topic() -> str:
+    mapping_file = (
+        Path(__file__).resolve().parents[2]
+        / "op_bootstrap"
+        / "app"
+        / "config"
+        / "so_mapping.yaml"
+    )
+    with open(mapping_file, "r", encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    return mapping["topics"][SO_NAME]
+
+
+def _listen() -> None:
+    consumer = KafkaConsumer(_get_topic())
     for msg in consumer:
         # TODO: handle incoming messages
         print(msg.value)

--- a/Bibind/so_conception/kafka/producer.py
+++ b/Bibind/so_conception/kafka/producer.py
@@ -1,6 +1,23 @@
 """Optional Kafka producer for conception events."""
 
 from kafka import KafkaProducer
+from pathlib import Path
+import yaml
+
+SO_NAME = "so_conception"
+
+
+def _get_topic() -> str:
+    mapping_file = (
+        Path(__file__).resolve().parents[2]
+        / "op_bootstrap"
+        / "app"
+        / "config"
+        / "so_mapping.yaml"
+    )
+    with open(mapping_file, "r", encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    return mapping["topics"][SO_NAME]
 
 
 def get_producer() -> KafkaProducer:

--- a/Bibind/so_organisation/kafka/consumer.py
+++ b/Bibind/so_organisation/kafka/consumer.py
@@ -2,10 +2,27 @@
 
 from threading import Thread
 from kafka import KafkaConsumer
+from pathlib import Path
+import yaml
+
+SO_NAME = "so_organisation"
+
+
+def _get_topic() -> str:
+    mapping_file = (
+        Path(__file__).resolve().parents[2]
+        / "op_bootstrap"
+        / "app"
+        / "config"
+        / "so_mapping.yaml"
+    )
+    with open(mapping_file, "r", encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    return mapping["topics"][SO_NAME]
 
 
 def _listen() -> None:
-    consumer = KafkaConsumer('organisation-topic')
+    consumer = KafkaConsumer(_get_topic())
     for msg in consumer:
         # TODO: handle incoming messages
         print(msg.value)

--- a/Bibind/so_organisation/kafka/producer.py
+++ b/Bibind/so_organisation/kafka/producer.py
@@ -1,6 +1,23 @@
 """Optional Kafka producer for organisation events."""
 
 from kafka import KafkaProducer
+from pathlib import Path
+import yaml
+
+SO_NAME = "so_organisation"
+
+
+def _get_topic() -> str:
+    mapping_file = (
+        Path(__file__).resolve().parents[2]
+        / "op_bootstrap"
+        / "app"
+        / "config"
+        / "so_mapping.yaml"
+    )
+    with open(mapping_file, "r", encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    return mapping["topics"][SO_NAME]
 
 
 def get_producer() -> KafkaProducer:

--- a/Bibind/so_planification/kafka/consumer.py
+++ b/Bibind/so_planification/kafka/consumer.py
@@ -2,10 +2,27 @@
 
 from threading import Thread
 from kafka import KafkaConsumer
+from pathlib import Path
+import yaml
+
+SO_NAME = "so_planification"
+
+
+def _get_topic() -> str:
+    mapping_file = (
+        Path(__file__).resolve().parents[2]
+        / "op_bootstrap"
+        / "app"
+        / "config"
+        / "so_mapping.yaml"
+    )
+    with open(mapping_file, "r", encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    return mapping["topics"][SO_NAME]
 
 
 def _listen():
-    consumer = KafkaConsumer('planification-topic')
+    consumer = KafkaConsumer(_get_topic())
     for msg in consumer:
         # TODO: handle incoming messages
         print(msg.value)

--- a/Bibind/so_planification/kafka/producer.py
+++ b/Bibind/so_planification/kafka/producer.py
@@ -1,6 +1,23 @@
 """Optional Kafka producer for planification events."""
 
 from kafka import KafkaProducer
+from pathlib import Path
+import yaml
+
+SO_NAME = "so_planification"
+
+
+def _get_topic() -> str:
+    mapping_file = (
+        Path(__file__).resolve().parents[2]
+        / "op_bootstrap"
+        / "app"
+        / "config"
+        / "so_mapping.yaml"
+    )
+    with open(mapping_file, "r", encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    return mapping["topics"][SO_NAME]
 
 
 def get_producer() -> KafkaProducer:

--- a/Bibind/so_qualite/kafka/consumer.py
+++ b/Bibind/so_qualite/kafka/consumer.py
@@ -2,10 +2,27 @@
 
 from threading import Thread
 from kafka import KafkaConsumer
+from pathlib import Path
+import yaml
+
+SO_NAME = "so_qualite"
+
+
+def _get_topic() -> str:
+    mapping_file = (
+        Path(__file__).resolve().parents[2]
+        / "op_bootstrap"
+        / "app"
+        / "config"
+        / "so_mapping.yaml"
+    )
+    with open(mapping_file, "r", encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    return mapping["topics"][SO_NAME]
 
 
 def _listen():
-    consumer = KafkaConsumer('qualite-topic')
+    consumer = KafkaConsumer(_get_topic())
     for msg in consumer:
         # TODO: handle incoming messages
         print(msg.value)

--- a/Bibind/so_qualite/kafka/producer.py
+++ b/Bibind/so_qualite/kafka/producer.py
@@ -1,6 +1,23 @@
 """Optional Kafka producer for qualite events."""
 
 from kafka import KafkaProducer
+from pathlib import Path
+import yaml
+
+SO_NAME = "so_qualite"
+
+
+def _get_topic() -> str:
+    mapping_file = (
+        Path(__file__).resolve().parents[2]
+        / "op_bootstrap"
+        / "app"
+        / "config"
+        / "so_mapping.yaml"
+    )
+    with open(mapping_file, "r", encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    return mapping["topics"][SO_NAME]
 
 
 def get_producer() -> KafkaProducer:

--- a/Bibind/so_realisation/kafka/consumer.py
+++ b/Bibind/so_realisation/kafka/consumer.py
@@ -2,10 +2,27 @@
 
 from threading import Thread
 from kafka import KafkaConsumer
+from pathlib import Path
+import yaml
+
+SO_NAME = "so_realisation"
+
+
+def _get_topic() -> str:
+    mapping_file = (
+        Path(__file__).resolve().parents[2]
+        / "op_bootstrap"
+        / "app"
+        / "config"
+        / "so_mapping.yaml"
+    )
+    with open(mapping_file, "r", encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    return mapping["topics"][SO_NAME]
 
 
 def _listen() -> None:
-    consumer = KafkaConsumer('realisation-topic')
+    consumer = KafkaConsumer(_get_topic())
     for msg in consumer:
         # TODO: handle incoming messages
         print(msg.value)

--- a/Bibind/so_realisation/kafka/producer.py
+++ b/Bibind/so_realisation/kafka/producer.py
@@ -1,6 +1,23 @@
 """Optional Kafka producer for realisation events."""
 
 from kafka import KafkaProducer
+from pathlib import Path
+import yaml
+
+SO_NAME = "so_realisation"
+
+
+def _get_topic() -> str:
+    mapping_file = (
+        Path(__file__).resolve().parents[2]
+        / "op_bootstrap"
+        / "app"
+        / "config"
+        / "so_mapping.yaml"
+    )
+    with open(mapping_file, "r", encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    return mapping["topics"][SO_NAME]
 
 
 def get_producer() -> KafkaProducer:

--- a/Bibind/so_release/kafka/consumer.py
+++ b/Bibind/so_release/kafka/consumer.py
@@ -2,10 +2,27 @@
 
 from threading import Thread
 from kafka import KafkaConsumer
+from pathlib import Path
+import yaml
+
+SO_NAME = "so_release"
+
+
+def _get_topic() -> str:
+    mapping_file = (
+        Path(__file__).resolve().parents[2]
+        / "op_bootstrap"
+        / "app"
+        / "config"
+        / "so_mapping.yaml"
+    )
+    with open(mapping_file, "r", encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    return mapping["topics"][SO_NAME]
 
 
 def _listen() -> None:
-    consumer = KafkaConsumer('release-topic')
+    consumer = KafkaConsumer(_get_topic())
     for msg in consumer:
         # TODO: handle incoming messages
         print(msg.value)

--- a/Bibind/so_release/kafka/producer.py
+++ b/Bibind/so_release/kafka/producer.py
@@ -1,6 +1,23 @@
 """Optional Kafka producer for release events."""
 
 from kafka import KafkaProducer
+from pathlib import Path
+import yaml
+
+SO_NAME = "so_release"
+
+
+def _get_topic() -> str:
+    mapping_file = (
+        Path(__file__).resolve().parents[2]
+        / "op_bootstrap"
+        / "app"
+        / "config"
+        / "so_mapping.yaml"
+    )
+    with open(mapping_file, "r", encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    return mapping["topics"][SO_NAME]
 
 
 def get_producer() -> KafkaProducer:

--- a/scripts/create_topics.sh
+++ b/scripts/create_topics.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Simple helper to create Kafka topics defined in so_mapping.yaml
+
+MAPPING_FILE="$(dirname "$0")/../Bibind/op_bootstrap/app/config/so_mapping.yaml"
+BOOTSTRAP_SERVERS=${BOOTSTRAP_SERVERS:-localhost:9092}
+
+if ! command -v kafka-topics >/dev/null 2>&1; then
+  echo "kafka-topics command not found" >&2
+  exit 1
+fi
+
+TOPICS=$(python - <<PY
+import yaml,sys
+with open('$MAPPING_FILE') as f:
+    data=yaml.safe_load(f)
+for t in data['topics'].values():
+    print(t)
+PY
+)
+
+for topic in $TOPICS; do
+  kafka-topics --bootstrap-server "$BOOTSTRAP_SERVERS" --create --if-not-exists --topic "$topic"
+done


### PR DESCRIPTION
## Summary
- add a mapping for SO topics
- implement generic Kafka producer/consumer for `op_bootstrap`
- update every SO to read topic names from the mapping file
- add helper script to create topics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688b89bad8848325b0fe50ce149428cd