### PR TITLE
Add Makefile for Docker setup automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: check-docker install-docker setup all
+
+check-docker:
+	@echo "Vérification de l'installation de Docker..."
+	@if command -v docker >/dev/null 2>&1; then \
+		echo "Docker est installé."; \
+	else \
+		echo "Docker n'est pas installé."; \
+		exit 1; \
+	fi
+
+install-docker:
+	@if ! command -v docker >/dev/null 2>&1; then \
+		echo "Installation de Docker..."; \
+		curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh; \
+		rm -f get-docker.sh; \
+	else \
+		echo "Docker est déjà installé."; \
+	fi
+
+setup: install-docker
+	@echo "Lancement des scripts de configuration..."
+	@if [ -f ./setup.sh ]; then \
+		echo "Exécution de ./setup.sh"; \
+		bash ./setup.sh; \
+	else \
+		echo "Aucun script setup.sh trouvé."; \
+	fi
+
+all: setup
+	@echo "Configuration complète."


### PR DESCRIPTION
## Summary
- add Makefile with targets to check/install Docker and run project setup scripts

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app'; ModuleNotFoundError: No module named 'main')*

------
https://chatgpt.com/codex/tasks/task_e_689050c0246c8325858b042fcb7b3e77