### PR TITLE
Add initial Groupodoo chat module

### DIFF
--- a/partenaires/groupodoo/README.md
+++ b/partenaires/groupodoo/README.md
@@ -1,0 +1,26 @@
+# Groupodoo Chat Module
+
+This module adds simple chat widgets connected to the Bibind API. It defines
+basic models for chat sessions and messages, a minimal controller for sending
+messages and receiving webhook callbacks, and frontend assets for displaying the
+chat in Odoo.
+
+## Installation
+
+Add this module to your Odoo addons path and update the app list. Enable the
+`Groupodoo` application and configure the API keys in *Settings > General
+Settings*.
+
+## Endpoints
+
+- `/groupodoo/api/chat/send` – send a message for a session.
+- `/groupodoo/api/chat/webhook` – receive messages from Bibind (signed via
+  `X-Bibind-Signature`).
+
+## Testing
+
+Run the Python tests with:
+
+```bash
+pytest partenaires/groupodoo/tests -q
+```

--- a/partenaires/groupodoo/__init__.py
+++ b/partenaires/groupodoo/__init__.py
@@ -1,0 +1,5 @@
+try:
+    from . import models  # noqa: F401
+    from . import controllers  # noqa: F401
+except Exception:  # pragma: no cover - allows running tests without odoo
+    pass

--- a/partenaires/groupodoo/__manifest__.py
+++ b/partenaires/groupodoo/__manifest__.py
@@ -1,0 +1,29 @@
+{
+  "name": "Group Odoo Chat (Bibind/n8n)",
+  "version": "18.0.1.0.0",
+  "summary": "Widgets de chat connectés à Bibind (op_bootstrap) pour lancer des workflows n8n avec agents IA",
+  "author": "Bibind",
+  "category": "Productivity",
+  "depends": ["base", "web", "bus", "mail"],
+  "data": [
+    "security/ir.model.access.csv",
+    "security/groupodoo_security.xml",
+    "views/chat_session_views.xml",
+    "views/res_config_settings_views.xml",
+    "data/params.xml",
+  ],
+  "assets": {
+    "web.assets_backend": [
+      "groupodoo/static/src/js/chat_widget.js",
+      "groupodoo/static/src/xml/chat_widget.xml",
+      "groupodoo/static/src/scss/chat.scss",
+    ],
+    "web.assets_frontend": [
+      "groupodoo/static/src/js/chat_widget.js",
+      "groupodoo/static/src/xml/chat_widget.xml",
+      "groupodoo/static/src/scss/chat.scss",
+    ],
+  },
+  "application": True,
+  "license": "LGPL-3",
+}

--- a/partenaires/groupodoo/controllers/__init__.py
+++ b/partenaires/groupodoo/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/partenaires/groupodoo/controllers/main.py
+++ b/partenaires/groupodoo/controllers/main.py
@@ -1,0 +1,75 @@
+import hmac
+import json
+import uuid
+from odoo import http
+from odoo.http import request
+from ..utils import compute_hmac
+
+
+class GroupodooController(http.Controller):
+    """Minimal controller handling chat messages."""
+
+    @http.route("/groupodoo/csrf", type="json", auth="user")
+    def csrf(self):
+        """Return CSRF token for widgets."""
+        return {"token": request.csrf_token()}
+
+    @http.route(
+        "/groupodoo/api/chat/send",
+        type="json",
+        auth="user",
+        methods=["POST"],
+        csrf=True,
+    )
+    def send(self, session_uuid=None, message=None, **kw):
+        env = request.env
+        session = env["groupodoo.chat.session"].sudo().search(
+            [("uuid", "=", session_uuid)], limit=1
+        )
+        if not session:
+            return http.Response(status=404)
+        user = request.env.user
+        if user.has_group("base.group_portal") and session.user_id.id != user.id:
+            return http.Response(status=403)
+        env["groupodoo.chat.message"].sudo().create(
+            {
+                "session_id": session.id,
+                "direction": "outbound",
+                "role": "user",
+                "content": message or "",
+            }
+        )
+        return {"ok": True, "idempotency_key": str(uuid.uuid4())}
+
+    @http.route(
+        "/groupodoo/api/chat/webhook",
+        type="json",
+        auth="public",
+        methods=["POST"],
+        csrf=False,
+    )
+    def webhook(self, **kw):
+        raw = request.httprequest.data or b""
+        sig = request.httprequest.headers.get("X-Bibind-Signature", "")
+        secret = (
+            request.env["ir.config_parameter"].sudo().get_param("groupodoo_webhook_secret", "")
+        )
+        expected = compute_hmac(secret, raw)
+        if not hmac.compare_digest(sig, expected):
+            return http.Response(status=403)
+        data = json.loads(raw.decode("utf-8") or "{}")
+        session_uuid = data.get("session_uuid")
+        session = request.env["groupodoo.chat.session"].sudo().search(
+            [("uuid", "=", session_uuid)], limit=1
+        )
+        if session:
+            request.env["groupodoo.chat.message"].sudo().create(
+                {
+                    "session_id": session.id,
+                    "direction": "inbound",
+                    "role": data.get("role", "assistant"),
+                    "content": data.get("content", ""),
+                    "payload_json": data,
+                }
+            )
+        return {"status": "ok"}

--- a/partenaires/groupodoo/data/params.xml
+++ b/partenaires/groupodoo/data/params.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <data noupdate="1">
+        <record id="param_groupodoo_api_base_url" model="ir.config_parameter">
+            <field name="key">groupodoo_api_base_url</field>
+            <field name="value">https://api.bibind.local/</field>
+        </record>
+    </data>
+</odoo>

--- a/partenaires/groupodoo/models/__init__.py
+++ b/partenaires/groupodoo/models/__init__.py
@@ -1,0 +1,4 @@
+from . import chat_session
+from . import chat_message
+from . import user_link
+from . import res_config_settings

--- a/partenaires/groupodoo/models/chat_message.py
+++ b/partenaires/groupodoo/models/chat_message.py
@@ -1,0 +1,33 @@
+from odoo import api, fields, models, tools
+
+
+class ChatMessage(models.Model):
+    _name = "groupodoo.chat.message"
+    _description = "Groupodoo Chat Message"
+    _order = "ts desc"
+
+    session_id = fields.Many2one(
+        "groupodoo.chat.session", required=True, index=True, ondelete="cascade"
+    )
+    direction = fields.Selection(
+        [("outbound", "Outbound"), ("inbound", "Inbound")], required=True
+    )
+    role = fields.Selection(
+        [("user", "User"), ("assistant", "Assistant"), ("system", "System")],
+        default="user",
+    )
+    content = fields.Text()
+    payload_json = fields.Json()
+    error = fields.Char()
+    ts = fields.Datetime(default=fields.Datetime.now, index=True)
+
+    @api.model
+    def create(self, vals):
+        if vals.get("content"):
+            vals["content"] = tools.html_sanitize(vals["content"])
+        return super().create(vals)
+
+    def write(self, vals):
+        if vals.get("content"):
+            vals["content"] = tools.html_sanitize(vals["content"])
+        return super().write(vals)

--- a/partenaires/groupodoo/models/chat_session.py
+++ b/partenaires/groupodoo/models/chat_session.py
@@ -1,0 +1,47 @@
+import uuid
+from odoo import api, fields, models
+
+
+class ChatSession(models.Model):
+    _name = "groupodoo.chat.session"
+    _description = "Groupodoo Chat Session"
+    _order = "last_activity desc"
+
+    name = fields.Char(required=True)
+    uuid = fields.Char(
+        string="UUID",
+        required=True,
+        copy=False,
+        index=True,
+        default=lambda self: str(uuid.uuid4()),
+    )
+    user_id = fields.Many2one("res.users", required=True, index=True)
+    company_id = fields.Many2one(
+        "res.company", required=True, default=lambda self: self.env.company, index=True
+    )
+    state = fields.Selection(
+        [
+            ("draft", "Draft"),
+            ("active", "Active"),
+            ("closed", "Closed"),
+            ("error", "Error"),
+        ],
+        default="draft",
+        index=True,
+    )
+    bibind_conversation_id = fields.Char()
+    n8n_workflow_id = fields.Char()
+    last_activity = fields.Datetime()
+    idempotency_key = fields.Char(index=True)
+    privacy = fields.Selection(
+        [("portal", "Portal"), ("internal", "Internal")], default="portal"
+    )
+
+    _sql_constraints = [
+        ("uuid_unique", "unique(uuid)", "UUID must be unique."),
+        (
+            "idempotency_key_unique",
+            "unique(idempotency_key)",
+            "Idempotency key must be unique.",
+        ),
+    ]

--- a/partenaires/groupodoo/models/res_config_settings.py
+++ b/partenaires/groupodoo/models/res_config_settings.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    groupodoo_api_base_url = fields.Char(config_parameter="groupodoo_api_base_url")
+    groupodoo_webhook_secret = fields.Char(config_parameter="groupodoo_webhook_secret")

--- a/partenaires/groupodoo/models/user_link.py
+++ b/partenaires/groupodoo/models/user_link.py
@@ -1,0 +1,16 @@
+from odoo import fields, models
+
+
+class UserLink(models.Model):
+    _name = "groupodoo.user.link"
+    _description = "Groupodoo User Link"
+
+    user_id = fields.Many2one("res.users", required=True)
+    bibind_user_id = fields.Char()
+    external_meta = fields.Json()
+    last_sync = fields.Datetime()
+
+    _sql_constraints = [
+        ("user_unique", "unique(user_id)", "User already linked"),
+        ("bibind_unique", "unique(bibind_user_id)", "Bibind user already linked"),
+    ]

--- a/partenaires/groupodoo/security/groupodoo_security.xml
+++ b/partenaires/groupodoo/security/groupodoo_security.xml
@@ -1,0 +1,33 @@
+<odoo>
+    <data noupdate="1">
+        <record id="group_groupodoo_portal_agent" model="res.groups">
+            <field name="name">Groupodoo Portal Agent</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+            <field name="implied_ids" eval="[(4, ref('base.group_portal'))]"/>
+        </record>
+        <record id="group_groupodoo_internal_agent" model="res.groups">
+            <field name="name">Groupodoo Internal Agent</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+            <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
+        </record>
+        <record id="group_groupodoo_admin" model="res.groups">
+            <field name="name">Groupodoo Admin</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+            <field name="implied_ids" eval="[(4, ref('base.group_system'))]"/>
+        </record>
+
+        <record id="rule_session_portal_own" model="ir.rule">
+            <field name="name">Portal sees own sessions</field>
+            <field name="model_id" ref="model_groupodoo_chat_session"/>
+            <field name="groups" eval="[(4, ref('group_groupodoo_portal_agent'))]"/>
+            <field name="domain_force">[("user_id", "=", user.id)]</field>
+        </record>
+
+        <record id="rule_session_internal_company" model="ir.rule">
+            <field name="name">Internal sees company sessions</field>
+            <field name="model_id" ref="model_groupodoo_chat_session"/>
+            <field name="groups" eval="[(4, ref('group_groupodoo_internal_agent'))]"/>
+            <field name="domain_force">[("company_id", "=", user.company_id.id)]</field>
+        </record>
+    </data>
+</odoo>

--- a/partenaires/groupodoo/security/ir.model.access.csv
+++ b/partenaires/groupodoo/security/ir.model.access.csv
@@ -1,0 +1,7 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_session_portal,session portal,model_groupodoo_chat_session,group_groupodoo_portal_agent,1,1,1,0
+access_message_portal,message portal,model_groupodoo_chat_message,group_groupodoo_portal_agent,1,0,1,0
+access_session_internal,session internal,model_groupodoo_chat_session,group_groupodoo_internal_agent,1,1,1,1
+access_message_internal,message internal,model_groupodoo_chat_message,group_groupodoo_internal_agent,1,1,1,1
+access_session_admin,session admin,model_groupodoo_chat_session,group_groupodoo_admin,1,1,1,1
+access_message_admin,message admin,model_groupodoo_chat_message,group_groupodoo_admin,1,1,1,1

--- a/partenaires/groupodoo/static/src/js/chat_widget.js
+++ b/partenaires/groupodoo/static/src/js/chat_widget.js
@@ -1,0 +1,25 @@
+odoo.define('groupodoo.chat_widget', function (require) {
+    'use strict';
+
+    const {Component, useState} = owl;
+    const rpc = require('web.rpc');
+
+    class GroupodooChatWidget extends Component {
+        setup() {
+            this.state = useState({messages: []});
+        }
+
+        async sendMessage(text) {
+            const resp = await rpc.query({
+                route: '/groupodoo/api/chat/send',
+                params: {session_uuid: this.props.sessionUuid, message: text},
+            });
+            if (resp && resp.ok) {
+                this.state.messages.push({role: 'user', content: text});
+            }
+        }
+    }
+    GroupodooChatWidget.template = 'groupodoo.chat_widget';
+
+    return GroupodooChatWidget;
+});

--- a/partenaires/groupodoo/static/src/scss/chat.scss
+++ b/partenaires/groupodoo/static/src/scss/chat.scss
@@ -1,0 +1,14 @@
+.o_groupodoo_widget {
+    border: 1px solid #ccc;
+    padding: 8px;
+    max-height: 300px;
+    overflow-y: auto;
+}
+.o_groupodoo_widget .msg-user {
+    text-align: right;
+    color: #1976d2;
+}
+.o_groupodoo_widget .msg-assistant {
+    text-align: left;
+    color: #333;
+}

--- a/partenaires/groupodoo/static/src/xml/chat_widget.xml
+++ b/partenaires/groupodoo/static/src/xml/chat_widget.xml
@@ -1,0 +1,11 @@
+<templates xml:space="preserve">
+    <t t-name="groupodoo.chat_widget">
+        <div class="o_groupodoo_widget">
+            <t t-foreach="state.messages" t-as="msg">
+                <div t-att-class="'msg-' + msg.role">
+                    <t t-esc="msg.content"/>
+                </div>
+            </t>
+        </div>
+    </t>
+</templates>

--- a/partenaires/groupodoo/tests/test_utils.py
+++ b/partenaires/groupodoo/tests/test_utils.py
@@ -1,0 +1,15 @@
+import importlib.util
+import pathlib
+
+utils_path = pathlib.Path(__file__).resolve().parents[1] / "utils.py"
+spec = importlib.util.spec_from_file_location("groupodoo_utils", utils_path)
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+
+
+def test_compute_hmac_consistency():
+    secret = "secret"
+    data = b"payload"
+    sig1 = utils.compute_hmac(secret, data)
+    sig2 = utils.compute_hmac(secret, data)
+    assert sig1 == sig2

--- a/partenaires/groupodoo/utils.py
+++ b/partenaires/groupodoo/utils.py
@@ -1,0 +1,7 @@
+import hmac
+import hashlib
+
+
+def compute_hmac(secret: str, data: bytes) -> str:
+    """Compute HMAC-SHA256 signature."""
+    return hmac.new(secret.encode(), data, hashlib.sha256).hexdigest()

--- a/partenaires/groupodoo/views/chat_session_views.xml
+++ b/partenaires/groupodoo/views/chat_session_views.xml
@@ -1,0 +1,41 @@
+<odoo>
+    <data>
+        <record id="view_chat_session_form" model="ir.ui.view">
+            <field name="name">groupodoo.chat.session.form</field>
+            <field name="model">groupodoo.chat.session</field>
+            <field name="arch" type="xml">
+                <form string="Chat Session">
+                    <sheet>
+                        <group>
+                            <field name="name"/>
+                            <field name="user_id"/>
+                            <field name="state"/>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="view_chat_session_tree" model="ir.ui.view">
+            <field name="name">groupodoo.chat.session.tree</field>
+            <field name="model">groupodoo.chat.session</field>
+            <field name="arch" type="xml">
+                <tree>
+                    <field name="name"/>
+                    <field name="user_id"/>
+                    <field name="state"/>
+                    <field name="last_activity"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="action_chat_session" model="ir.actions.act_window">
+            <field name="name">Chat Sessions</field>
+            <field name="res_model">groupodoo.chat.session</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+
+        <menuitem id="menu_groupodoo_root" name="Groupodoo"/>
+        <menuitem id="menu_groupodoo_sessions" name="Chat Sessions" parent="menu_groupodoo_root" action="action_chat_session"/>
+    </data>
+</odoo>

--- a/partenaires/groupodoo/views/res_config_settings_views.xml
+++ b/partenaires/groupodoo/views/res_config_settings_views.xml
@@ -1,0 +1,26 @@
+<odoo>
+    <data>
+        <record id="res_config_settings_view_form_groupodoo" model="ir.ui.view">
+            <field name="name">res.config.settings.view.form.groupodoo</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="base.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[@id='settings']" position="inside">
+                    <div class="app_settings_block" data-string="Groupodoo">
+                        <h2>Groupodoo</h2>
+                        <div class="row mt16 o_settings_container">
+                            <div class="col-12 col-lg-6">
+                                <div class="o_setting_box">
+                                    <field name="groupodoo_api_base_url"/>
+                                </div>
+                                <div class="o_setting_box">
+                                    <field name="groupodoo_webhook_secret" password="True"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
## Summary
- scaffold Groupodoo module with chat session, message, and user link models
- add minimal controller and utilities to send messages and verify webhook signatures
- include security groups, views, assets, and configuration settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `pytest partenaires/groupodoo/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e62bfcc88325859269886b99c7ec