### PR TITLE
Add Juju charm skeletons and sample bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install deps
+        run: |
+          pip install -r charms/helm-orchestrator/requirements.txt
+          pip install -r charms/operator-applier/requirements.txt
+          pip install pytest flake8 black
+      - name: Lint
+        run: |
+          black --check charms
+          flake8 charms
+      - name: Test
+        run: |
+          pytest charms/helm-orchestrator/src/tests charms/operator-applier/src/tests -q
+      - name: Pack
+        run: |
+          charmcraft pack -p charms/helm-orchestrator
+          charmcraft pack -p charms/operator-applier

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # BibindApi
+
 Api Bibind
+
+## Juju charms
+
+This repository also hosts experimental Juju charms and bundles under the `charms/`, `catalog/` and `bundles/` directories. These provide a Helm orchestrator and an operator applier charm along with a sample bundle and catalog.

--- a/bundles/stack/README.md
+++ b/bundles/stack/README.md
@@ -1,0 +1,9 @@
+# Stack bundle
+
+Example Juju bundle deploying the Helm orchestrator with an operator applier.
+
+Deploy with:
+
+```bash
+juju deploy ./bundle.yaml
+```

--- a/bundles/stack/bundle.yaml
+++ b/bundles/stack/bundle.yaml
@@ -1,0 +1,21 @@
+bundle: kubernetes
+applications:
+  operator-applier:
+    charm: ./../../charms/operator-applier
+  helm-orchestrator:
+    charm: ./../../charms/helm-orchestrator
+    options:
+      use-catalog: true
+      catalog-path: ./../../catalog/charts-example.yaml
+  ingress-nginx:
+    charm: ingress-nginx
+  cert-manager:
+    charm: cert-manager
+  pgbouncer-k8s:
+    charm: pgbouncer-k8s
+  postgresql-k8s:
+    charm: postgresql-k8s
+relations:
+  - [helm-orchestrator:ingress, ingress-nginx:ingress]
+  - [helm-orchestrator:database, pgbouncer-k8s:postgresql_client]
+  - [pgbouncer-k8s:db, postgresql-k8s:postgresql]

--- a/catalog/charts-example.json
+++ b/catalog/charts-example.json
@@ -1,0 +1,31 @@
+{
+  "charts": [
+    {
+      "name": "odoo",
+      "source": "oci://registry-1.docker.io/bitnamicharts/odoo",
+      "versions": ["23.1.1", "23.1.2"],
+      "defaults": {
+        "ingress": {
+          "enabled": true,
+          "annotations": {
+            "nginx.ingress.kubernetes.io/affinity": "cookie"
+          }
+        },
+        "resources": {
+          "requests": {"cpu": "500m", "memory": "1Gi"},
+          "limits": {"cpu": "1500m", "memory": "2Gi"}
+        }
+      },
+      "values_schema": {
+        "allowed_keys": [
+          "ingress.enabled",
+          "ingress.annotations",
+          "resources.requests.cpu",
+          "resources.requests.memory",
+          "resources.limits.cpu",
+          "resources.limits.memory"
+        ]
+      }
+    }
+  ]
+}

--- a/catalog/charts-example.yaml
+++ b/catalog/charts-example.yaml
@@ -1,0 +1,24 @@
+charts:
+- name: odoo
+  source: oci://registry-1.docker.io/bitnamicharts/odoo
+  versions: ["23.1.1", "23.1.2"]
+  defaults:
+    ingress:
+      enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/affinity: "cookie"
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "1500m"
+        memory: "2Gi"
+  values_schema:
+    allowed_keys:
+      - ingress.enabled
+      - ingress.annotations
+      - resources.requests.cpu
+      - resources.requests.memory
+      - resources.limits.cpu
+      - resources.limits.memory

--- a/catalog/schema.json
+++ b/catalog/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "charts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "source": {"type": "string"},
+          "versions": {"type": "array", "items": {"type": "string"}},
+          "defaults": {"type": "object"},
+          "values_schema": {
+            "type": "object",
+            "properties": {
+              "allowed_keys": {
+                "type": "array",
+                "items": {"type": "string"}
+              }
+            }
+          }
+        },
+        "required": ["name", "versions"]
+      }
+    }
+  },
+  "required": ["charts"]
+}

--- a/charms/helm-orchestrator/actions.yaml
+++ b/charms/helm-orchestrator/actions.yaml
@@ -1,0 +1,26 @@
+upgrade:
+  description: Upgrade Helm chart to --version
+  params:
+    version:
+      type: string
+rollback:
+  description: Rollback to previous Helm revision
+  params:
+    revision:
+      type: integer
+dry-run:
+  description: Render and diff without applying
+diff:
+  description: Show live vs rendered manifest diff
+purge:
+  description: Uninstall Helm release
+scale:
+  description: Set replicas (if chart supports it)
+  params:
+    replicas:
+      type: integer
+set-values:
+  description: Merge YAML overrides into current values
+  params:
+    values:
+      type: string

--- a/charms/helm-orchestrator/charmcraft.yaml
+++ b/charms/helm-orchestrator/charmcraft.yaml
@@ -1,0 +1,8 @@
+type: charm
+bases:
+  - name: ubuntu
+    channel: "22.04/stable"
+parts:
+  charm:
+    plugin: charm
+    source: .

--- a/charms/helm-orchestrator/config.yaml
+++ b/charms/helm-orchestrator/config.yaml
@@ -1,0 +1,31 @@
+options:
+  chart:
+    type: string
+    default: "oci://registry.example.com/odoo"
+  version:
+    type: string
+    default: "1.2.3"
+  release:
+    type: string
+    default: "odoo"
+  namespace:
+    type: string
+    default: "odoo"
+  values-override:
+    type: string
+    default: ""
+  use-catalog:
+    type: boolean
+    default: true
+  catalog-path:
+    type: string
+    default: "../catalog/charts-example.yaml"
+  create-crds:
+    type: boolean
+    default: true
+  atomic-upgrade:
+    type: boolean
+    default: true
+  wait-timeout:
+    type: int
+    default: 900

--- a/charms/helm-orchestrator/metadata.yaml
+++ b/charms/helm-orchestrator/metadata.yaml
@@ -1,0 +1,13 @@
+name: helm-orchestrator
+type: charm
+bases:
+  - name: ubuntu
+    channel: 22.04/stable
+requires:
+  ingress:
+    interface: ingress
+  database:
+    interface: postgresql_client
+provides:
+  metrics-endpoint:
+    interface: prometheus_scrape

--- a/charms/helm-orchestrator/requirements.txt
+++ b/charms/helm-orchestrator/requirements.txt
@@ -1,0 +1,6 @@
+ops>=2.11
+ops-lib-helm>=0.2
+lightkube
+lightkube-models
+jinja2
+pyyaml

--- a/charms/helm-orchestrator/src/catalog.py
+++ b/charms/helm-orchestrator/src/catalog.py
@@ -1,0 +1,56 @@
+"""Catalog policy utilities."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+
+class CatalogViolation(Exception):
+    """Raised when catalog validation fails."""
+
+
+@dataclass
+class _ChartEntry:
+    name: str
+    source: str
+    versions: List[str]
+    defaults: Dict[str, Any]
+    allowed_keys: List[str]
+
+
+class CatalogPolicy:
+    """Simple in-memory representation of the catalog."""
+
+    def __init__(self, charts: Dict[str, _ChartEntry]):
+        self._charts = charts
+
+    @classmethod
+    def from_path(cls, path: Path) -> "CatalogPolicy":
+        data = yaml.safe_load(path.read_text())
+        charts: Dict[str, _ChartEntry] = {}
+        for entry in data.get("charts", []):
+            charts[entry["name"]] = _ChartEntry(
+                name=entry["name"],
+                source=entry.get("source", ""),
+                versions=entry.get("versions", []),
+                defaults=entry.get("defaults", {}),
+                allowed_keys=entry.get("values_schema", {}).get("allowed_keys", []),
+            )
+        return cls(charts)
+
+    def allowed(self, chart: str, version: str) -> bool:
+        entry = self._charts.get(chart)
+        return bool(entry and version in entry.versions)
+
+    def defaults_for(self, chart: str) -> Dict[str, Any]:
+        entry = self._charts.get(chart)
+        return dict(entry.defaults) if entry else {}
+
+    def allowed_keys(self, chart: str) -> List[str]:
+        entry = self._charts.get(chart)
+        return list(entry.allowed_keys) if entry else []

--- a/charms/helm-orchestrator/src/charm.py
+++ b/charms/helm-orchestrator/src/charm.py
@@ -1,0 +1,113 @@
+"""Helm orchestrator charm."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+from ops.charm import CharmBase, ActionEvent
+from ops.main import main
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+
+from .catalog import CatalogPolicy, CatalogViolation
+from .validators import merge_values_validated
+from .helm_release import HelmRelease
+
+log = logging.getLogger(__name__)
+
+
+class HelmOrchestratorCharm(CharmBase):
+    """Charm orchestrating a Helm release.
+
+    SECURITY: never log secrets.
+    """
+
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+        self._helm = HelmRelease(
+            self, self.config.get("release"), self.config.get("namespace")
+        )
+        self.framework.observe(self.on.install, self._reconcile)
+        self.framework.observe(self.on.config_changed, self._reconcile)
+        self.framework.observe(self.on.upgrade_action, self._upgrade_action)
+        self.framework.observe(self.on.rollback_action, self._rollback_action)
+        self.framework.observe(self.on.dry_run_action, self._dry_run_action)
+        self.framework.observe(self.on.diff_action, self._diff_action)
+        self.framework.observe(self.on.purge_action, self._purge_action)
+
+    # ------------------------------------------------------------------
+    # Helpers
+
+    def _render_values(self) -> Dict[str, Any]:
+        """Assemble Helm values from defaults, overrides and catalog policy."""
+
+        base: Dict[str, Any] = {}
+        policy = None
+        if self.config.get("use-catalog"):
+            policy = CatalogPolicy.from_path(Path(self.config["catalog-path"]))
+            if not policy.allowed(self.config["chart"], self.config["version"]):
+                raise CatalogViolation("chart or version not allowed")
+            base = policy.defaults_for(self.config["chart"])
+            allowed_keys = policy.allowed_keys(self.config["chart"])
+        else:
+            allowed_keys = None
+
+        overrides = yaml.safe_load(self.config["values-override"] or "{}")
+        merged = merge_values_validated(base, overrides, allowed_keys)
+        # TODO: relation data injection
+        return merged
+
+    # ------------------------------------------------------------------
+    # Hooks
+
+    def _reconcile(self, _event: ActionEvent) -> None:
+        """Main reconcile path."""
+
+        try:
+            values = self._render_values()
+            self._helm.install(
+                chart=self.config["chart"],
+                values=values,
+                version=self.config["version"],
+                atomic=bool(self.config["atomic-upgrade"]),
+                wait=True,
+                timeout=int(self.config["wait-timeout"]),
+            )
+            self.unit.status = ActiveStatus(
+                f"deployed {self.config['chart']}@{self.config['version']}"
+            )
+        except CatalogViolation as exc:
+            self.unit.status = BlockedStatus(str(exc))
+        except Exception as exc:  # noqa: BLE001 - surface helm failure
+            log.exception("reconcile failed")
+            self.unit.status = BlockedStatus(f"helm failed: {exc}")
+
+    # ------------------------------------------------------------------
+    # Actions (minimal stubs)
+
+    def _upgrade_action(self, event: ActionEvent) -> None:
+        self._reconcile(event)
+
+    def _rollback_action(self, event: ActionEvent) -> None:
+        revision = event.params.get("revision")
+        self._helm.rollback(revision)
+        event.set_results({"result": "rolled back"})
+
+    def _dry_run_action(self, event: ActionEvent) -> None:
+        diff = self._helm.dry_run(
+            self.config["chart"], self.config["version"], self._render_values()
+        )
+        event.set_results({"diff": diff})
+
+    def _diff_action(self, event: ActionEvent) -> None:
+        event.set_results({"diff": self._helm.diff(self._render_values())})
+
+    def _purge_action(self, event: ActionEvent) -> None:
+        self._helm.remove()
+        event.set_results({"result": "removed"})
+
+
+if __name__ == "__main__":
+    main(HelmOrchestratorCharm)

--- a/charms/helm-orchestrator/src/helm_release.py
+++ b/charms/helm-orchestrator/src/helm_release.py
@@ -1,0 +1,45 @@
+"""Minimal HelmRelease wrapper for tests."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class HelmRelease:  # pragma: no cover - wrapper simplified for tests
+    """Tiny stand-in for ops-lib-helm's HelmRelease."""
+
+    def __init__(self, charm: Any, release_name: str, namespace: str) -> None:
+        self.charm = charm
+        self.release_name = release_name
+        self.namespace = namespace
+        self.last_install: Dict[str, Any] | None = None
+
+    def install(
+        self,
+        chart: str,
+        values: Dict[str, Any],
+        version: str,
+        atomic: bool,
+        wait: bool,
+        timeout: int,
+    ) -> None:
+        self.last_install = {
+            "chart": chart,
+            "values": values,
+            "version": version,
+            "atomic": atomic,
+            "wait": wait,
+            "timeout": timeout,
+        }
+
+    def rollback(self, revision: int | None) -> None:
+        self.last_install = {"rollback": revision}
+
+    def dry_run(self, chart: str, version: str, values: Dict[str, Any]) -> str:
+        return "DRY-RUN"
+
+    def diff(self, values: Dict[str, Any]) -> str:
+        return "DIFF"
+
+    def remove(self) -> None:
+        self.last_install = None

--- a/charms/helm-orchestrator/src/templates/values.j2
+++ b/charms/helm-orchestrator/src/templates/values.j2
@@ -1,0 +1,1 @@
+# jinja2 template for values (placeholder)

--- a/charms/helm-orchestrator/src/tests/test_charm.py
+++ b/charms/helm-orchestrator/src/tests/test_charm.py
@@ -1,0 +1,42 @@
+"""Unit tests for HelmOrchestratorCharm."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from ops.model import ActiveStatus, BlockedStatus
+from ops.testing import Harness
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from charm import HelmOrchestratorCharm  # noqa: E402
+
+
+def test_blocked_when_chart_not_in_catalog(tmp_path):
+    harness = Harness(HelmOrchestratorCharm)
+    harness.begin()
+    harness.update_config(
+        {
+            "chart": "unknown",
+            "version": "1.0.0",
+            "use-catalog": True,
+            "catalog-path": "catalog/charts-example.yaml",
+        }
+    )
+    status = harness.model.unit.status
+    assert isinstance(status, BlockedStatus)
+
+
+def test_active_when_chart_allowed():
+    harness = Harness(HelmOrchestratorCharm)
+    harness.begin()
+    harness.update_config(
+        {
+            "chart": "odoo",
+            "version": "23.1.1",
+            "use-catalog": True,
+            "catalog-path": "catalog/charts-example.yaml",
+        }
+    )
+    status = harness.model.unit.status
+    assert isinstance(status, ActiveStatus)

--- a/charms/helm-orchestrator/src/validators.py
+++ b/charms/helm-orchestrator/src/validators.py
@@ -1,0 +1,47 @@
+"""Validation helpers."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, Iterable, List
+
+from .catalog import CatalogViolation
+
+
+def merge_values_validated(
+    base: Dict[str, Any], overrides: Dict[str, Any], allowed_keys: Iterable[str] | None
+) -> Dict[str, Any]:
+    """Merge two mappings while validating allowed keys.
+
+    Args:
+        base: Base values, typically from catalog defaults.
+        overrides: User provided overrides.
+        allowed_keys: Iterable of allowed dotted key paths.
+
+    Returns:
+        Merged dictionary of values.
+
+    Raises:
+        CatalogViolation: If an override key is not allowed.
+    """
+
+    allowed = set(allowed_keys or [])
+    result = deepcopy(base)
+
+    def _merge(prefix: List[str], dst: Dict[str, Any], src: Dict[str, Any]) -> None:
+        for key, value in src.items():
+            path = prefix + [key]
+            dotted = ".".join(path)
+            if allowed and dotted not in allowed:
+                raise CatalogViolation(f"override key {dotted} not allowed")
+            if isinstance(value, dict):
+                node = dst.setdefault(key, {})
+                if isinstance(node, dict):
+                    _merge(path, node, value)
+                else:
+                    dst[key] = deepcopy(value)
+            else:
+                dst[key] = value
+
+    _merge([], result, overrides)
+    return result

--- a/charms/operator-applier/actions.yaml
+++ b/charms/operator-applier/actions.yaml
@@ -1,0 +1,6 @@
+reapply:
+  description: Force reapplication of resources
+purge:
+  description: Attempt to delete applied resources
+status:
+  description: Report readiness of applied resources

--- a/charms/operator-applier/charmcraft.yaml
+++ b/charms/operator-applier/charmcraft.yaml
@@ -1,0 +1,8 @@
+type: charm
+bases:
+  - name: ubuntu
+    channel: "22.04/stable"
+parts:
+  charm:
+    plugin: charm
+    source: .

--- a/charms/operator-applier/config.yaml
+++ b/charms/operator-applier/config.yaml
@@ -1,0 +1,13 @@
+options:
+  apply-kustomize:
+    type: boolean
+    default: true
+  path:
+    type: string
+    default: "./src/resources"
+  wait-ready:
+    type: boolean
+    default: true
+  timeout:
+    type: int
+    default: 600

--- a/charms/operator-applier/metadata.yaml
+++ b/charms/operator-applier/metadata.yaml
@@ -1,0 +1,5 @@
+name: operator-applier
+type: charm
+bases:
+  - name: ubuntu
+    channel: 22.04/stable

--- a/charms/operator-applier/requirements.txt
+++ b/charms/operator-applier/requirements.txt
@@ -1,0 +1,3 @@
+ops>=2.11
+lightkube
+pyyaml

--- a/charms/operator-applier/src/charm.py
+++ b/charms/operator-applier/src/charm.py
@@ -1,0 +1,62 @@
+"""Operator-applier charm."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+from ops.charm import CharmBase, ActionEvent
+from ops.main import main
+from ops.model import ActiveStatus, BlockedStatus
+
+try:  # pragma: no cover - lightkube may not be installed in tests
+    from lightkube import Client
+except Exception:  # pragma: no cover
+
+    class Client:  # type: ignore
+        def apply(self, *a: Any, **kw: Any) -> None:  # noqa: D401 - dummy
+            pass
+
+
+log = logging.getLogger(__name__)
+
+
+class OperatorApplierCharm(CharmBase):
+    """Apply CRDs and manifests using lightkube."""
+
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+        self.client = Client()
+        self.framework.observe(self.on.install, self._reconcile)
+        self.framework.observe(self.on.config_changed, self._reconcile)
+
+    def _apply_path(self, path: Path) -> None:
+        for mf in path.glob("*.yaml"):
+            obj = yaml.safe_load(mf.read_text())
+            self.client.apply(obj, field_manager="operator-applier", force=True)
+
+    def _reconcile(self, _event: ActionEvent) -> None:
+        root = Path(self.config["path"])
+        if not root.exists():
+            self.unit.status = BlockedStatus("path not found")
+            return
+        self._apply_path(root / "crds")
+        self._apply_path(root / "manifests")
+        self.unit.status = ActiveStatus("applied")
+
+    # action stubs ------------------------------------------------------
+    def _reapply_action(self, event: ActionEvent) -> None:
+        self._reconcile(event)
+        event.set_results({"result": "reapplied"})
+
+    def _status_action(self, event: ActionEvent) -> None:
+        event.set_results({"status": self.unit.status.message})
+
+    def _purge_action(self, event: ActionEvent) -> None:
+        event.set_results({"result": "purge not implemented"})
+
+
+if __name__ == "__main__":  # pragma: no cover - main entry
+    main(OperatorApplierCharm)

--- a/charms/operator-applier/src/resources/crds/sample-crd.yaml
+++ b/charms/operator-applier/src/resources/crds/sample-crd.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: samples.example.com
+spec:
+  group: example.com
+  names:
+    kind: Sample
+    plural: samples
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/charms/operator-applier/src/resources/kustomization.yaml
+++ b/charms/operator-applier/src/resources/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - crds
+  - manifests

--- a/charms/operator-applier/src/resources/manifests/sample.yaml
+++ b/charms/operator-applier/src/resources/manifests/sample.yaml
@@ -1,0 +1,6 @@
+apiVersion: example.com/v1
+kind: Sample
+metadata:
+  name: sample
+spec:
+  foo: bar

--- a/charms/operator-applier/src/tests/test_charm.py
+++ b/charms/operator-applier/src/tests/test_charm.py
@@ -1,0 +1,34 @@
+"""Unit tests for OperatorApplierCharm."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from ops.model import ActiveStatus, BlockedStatus
+from ops.testing import Harness
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from charm import OperatorApplierCharm  # noqa: E402
+
+
+def test_blocked_when_path_missing(tmp_path):
+    harness = Harness(OperatorApplierCharm)
+    harness.begin()
+    harness.update_config({"path": str(tmp_path / "missing")})
+    status = harness.model.unit.status
+    assert isinstance(status, BlockedStatus)
+
+
+def test_active_when_path_exists(tmp_path):
+    resources = tmp_path / "res"
+    (resources / "crds").mkdir(parents=True)
+    (resources / "manifests").mkdir()
+    (resources / "crds/crd.yaml").write_text("{}")
+    (resources / "manifests/mf.yaml").write_text("{}")
+
+    harness = Harness(OperatorApplierCharm)
+    harness.begin()
+    harness.update_config({"path": str(resources)})
+    status = harness.model.unit.status
+    assert isinstance(status, ActiveStatus)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 88
+target-version = ["py310"]
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Root requirements for development
+pytest


### PR DESCRIPTION
## Summary
- add Helm orchestrator charm using catalog-driven validation
- add operator applier charm for CRD/manifest application
- provide sample bundle and chart catalog with CI skeleton

## Testing
- `black --check charms/helm-orchestrator charms/operator-applier`
- `flake8 charms/helm-orchestrator charms/operator-applier` *(fails: command not found)*
- `pytest charms/helm-orchestrator/src/tests charms/operator-applier/src/tests -q` *(fails: ModuleNotFoundError: No module named 'ops')*


------
https://chatgpt.com/codex/tasks/task_e_68a55573453083259dedef46aec32dab