### PR TITLE
Import ApiClientError for connection tests

### DIFF
--- a/partenaires/bibind_core/models/settings.py
+++ b/partenaires/bibind_core/models/settings.py
@@ -9,6 +9,8 @@ from typing import Any
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
+from .api_client import ApiClientError
+
 
 class ParamStore(models.AbstractModel):
     _name = "bibind.param.store"
@@ -116,7 +118,7 @@ class ResConfigSettings(models.TransientModel):
         client = self.env["bibind.api_client"]
         try:
             client.get_context("ping")
-        except ApiClientError as exc:  # type: ignore[name-defined]
+        except ApiClientError as exc:
             raise UserError(_("Connection failed: %s") % exc) from exc
         return {
             "type": "ir.actions.client",


### PR DESCRIPTION
## Summary
- add ApiClientError import to settings and handle it in action_test_connection

## Testing
- `flake8 partenaires/bibind_core/models/settings.py` *(fails: command not found)*
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile partenaires/bibind_core/models/settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6f19c14988325bc7cd70364e77690