### PR TITLE
feat: secure AI callback and relay events

### DIFF
--- a/partenaires/bibind_core/controllers/webhook.py
+++ b/partenaires/bibind_core/controllers/webhook.py
@@ -6,6 +6,7 @@ import hmac
 import json
 import logging
 import hashlib
+import time
 
 from odoo import http
 from odoo.http import request
@@ -19,14 +20,22 @@ def _check_signature(payload: bytes, signature: str, secret: str) -> bool:
 
 
 class BibindWebhookController(http.Controller):
-    @http.route("/bibind/webhook/audit", type="json", auth="public", csrf=False, methods=["POST"])
+    @http.route(
+        "/bibind/webhook/audit",
+        type="json",
+        auth="public",
+        csrf=False,
+        methods=["POST"],
+    )
     def audit_event(self):
         payload = request.httprequest.get_data() or b"{}"
         data = json.loads(payload)
         required = {"correlation_id", "event", "subject", "instance_id", "at"}
         if not required.issubset(data):
             return http.Response(status=400)
-        secret_ref = request.env["bibind.param.store"].get_param("webhook_hmac_secret_ref")
+        secret_ref = request.env["bibind.param.store"].get_param(
+            "webhook_hmac_secret_ref"
+        )
         if secret_ref:
             secret = request.env["bibind.api_client"].resolve_secret_ref(secret_ref)
             sig = request.httprequest.headers.get("X-Signature")
@@ -35,12 +44,33 @@ class BibindWebhookController(http.Controller):
         _logger.info(json.dumps({"event": "auditEvent", "payload": data}))
         return {"status": "ok"}
 
-    @http.route("/bibind/webhook/ai_callback", type="json", auth="public", csrf=False, methods=["POST"])
+    @http.route(
+        "/bibind/webhook/ai_callback",
+        type="json",
+        auth="public",
+        csrf=False,
+        methods=["POST"],
+    )
     def ai_callback(self):
+        start = time.monotonic()
         payload = request.httprequest.get_data() or b"{}"
         data = json.loads(payload)
         required = {"task_id", "status", "correlation_id"}
         if not required.issubset(data):
             return http.Response(status=400)
-        _logger.info(json.dumps({"event": "ai.task.status", "payload": data}))
+        secret_ref = request.env["bibind.param.store"].get_param(
+            "webhook_hmac_secret_ref"
+        )
+        if secret_ref:
+            secret = request.env["bibind.api_client"].resolve_secret_ref(secret_ref)
+            sig = request.httprequest.headers.get("X-Signature")
+            if not sig or not _check_signature(payload, sig, secret):
+                return http.Response(status=403)
+        request.env["bus.bus"].sendone("ai.task.status", data)
+        duration = time.monotonic() - start
+        _logger.info(
+            json.dumps(
+                {"event": "ai.task.status", "payload": data, "duration": duration}
+            )
+        )
         return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add HMAC verification and event relaying to AI callback
- log processing duration

## Testing
- `python -m black --quiet partenaires/bibind_core/controllers/webhook.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68a6f90e5a10832581c301144772ee5f