### PR TITLE
Expand Bibind core test coverage

### DIFF
--- a/partenaires/bibind_core/tests/test_api_client.py
+++ b/partenaires/bibind_core/tests/test_api_client.py
@@ -22,3 +22,61 @@ class ApiClientCase(TransactionCase):
         data = self.client.get_context("ping")
         assert data["pong"] is True
         assert m_req.call_args[1]["headers"]["Authorization"].startswith("Bearer ")
+
+    @mock.patch("requests.post")
+    @mock.patch("requests.Session.request")
+    def test_refresh_token_on_401(self, m_req, m_post):
+        token1 = mock.Mock()
+        token1.status_code = 200
+        token1.json.return_value = {"access_token": "t1", "expires_in": 60}
+        token2 = mock.Mock()
+        token2.status_code = 200
+        token2.json.return_value = {"access_token": "t2", "expires_in": 60}
+        m_post.side_effect = [token1, token2]
+        resp_401 = mock.Mock()
+        resp_401.status_code = 401
+        resp_ok = mock.Mock()
+        resp_ok.status_code = 200
+        resp_ok.json.return_value = {"pong": True}
+        m_req.side_effect = [resp_401, resp_ok]
+        data = self.client.get_context("ping")
+        assert data["pong"] is True
+        assert m_post.call_count == 2
+        # second request should use refreshed token
+        auth_header = m_req.call_args_list[-1][1]["headers"]["Authorization"]
+        assert auth_header == "Bearer t2"
+
+    @mock.patch("requests.post")
+    @mock.patch("requests.adapters.HTTPAdapter.send")
+    def test_retries_on_errors(self, m_send, m_post):
+        m_post.return_value.status_code = 200
+        m_post.return_value.json.return_value = {"access_token": "t", "expires_in": 60}
+        bad = mock.Mock()
+        bad.status_code = 500
+        bad.read = lambda *a, **k: b""  # needed by requests
+        good = mock.Mock()
+        good.status_code = 200
+        good.read = lambda *a, **k: b"{}"
+        good.json.return_value = {"pong": True}
+        m_send.side_effect = [bad, good]
+        data = self.client.get_context("ping")
+        assert data["pong"] is True
+        assert m_send.call_count == 2
+
+    @mock.patch("requests.post")
+    @mock.patch("requests.Session.request")
+    def test_circuit_breaker_open(self, m_req, m_post):
+        from odoo.addons.bibind_core.models.api_client import _CircuitBreaker, ApiClientServerError, ApiClientCircuitOpen
+
+        m_post.return_value.status_code = 200
+        m_post.return_value.json.return_value = {"access_token": "t", "expires_in": 60}
+        resp = mock.Mock()
+        resp.status_code = 500
+        m_req.return_value = resp
+        self.client._breaker = _CircuitBreaker(fail_max=1, reset_timeout_s=60)
+        with pytest.raises(ApiClientServerError):
+            self.client.get_context("ping")
+        with pytest.raises(ApiClientCircuitOpen):
+            self.client.get_context("ping")
+        # second call should not reach request due to open circuit
+        assert m_req.call_count == 1

--- a/partenaires/bibind_core/tests/test_security_rules.py
+++ b/partenaires/bibind_core/tests/test_security_rules.py
@@ -1,11 +1,32 @@
+import pytest
+
+from odoo import fields, models
+from odoo.exceptions import AccessError
 from odoo.tests.common import TransactionCase
+
+from odoo.addons.bibind_core.models.mixins import PceMixin
+
+
+class Dummy(models.Model, PceMixin):
+    _name = "bibind.test.pce"
+    name = fields.Char()
 
 
 class DummyModelCase(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.Dummy = cls.env['ir.model']
+        # register dummy model
+        cls.env.registry.models[Dummy._name] = Dummy
+        Dummy._build_model(cls.env.registry, cls.env.cr)
+        cls.env["ir.model"].create({"name": "Dummy", "model": Dummy._name})
+        cls.Dummy = cls.env[Dummy._name]
+        setattr(cls.env.user, "tenant_id", "t1")
 
-    def test_access_domain(self):
-        self.assertTrue(True)
+    def test_cross_tenant_access_error(self):
+        helpers = self.env["bibind.security.helpers"]
+        rec1 = self.Dummy.create({"name": "A", "tenant_id": "t1"})
+        helpers.check_tenant(rec1)  # should pass
+        rec2 = self.Dummy.create({"name": "B", "tenant_id": "t2"})
+        with pytest.raises(AccessError):
+            helpers.check_tenant(rec2)

--- a/partenaires/bibind_core/tests/test_webhooks.py
+++ b/partenaires/bibind_core/tests/test_webhooks.py
@@ -1,10 +1,74 @@
+import hmac
+import hashlib
 import json
+from unittest import mock
+
 from odoo.tests.common import HttpCase
 
 
 class WebhookCase(HttpCase):
-    def test_audit_webhook(self):
+    def _headers(self, sig=None):
+        headers = {"Content-Type": "application/json"}
+        if sig:
+            headers["X-Signature"] = sig
+        return headers
+
+    def test_hmac_validation(self):
         payload = {
-            'correlation_id': 'c1', 'event': 'e', 'subject': 's', 'instance_id': 'i', 'at': 'now'
+            "correlation_id": "c1",
+            "event": "e",
+            "subject": "s",
+            "instance_id": "i",
+            "at": "now",
         }
-        self.url_open('/bibind/webhook/audit', data=json.dumps(payload), method='POST')
+        secret = "s3"
+        ICP = self.env["ir.config_parameter"].sudo()
+        ICP.set_param("webhook_hmac_secret_ref", "ref")
+        sig = hmac.new(secret.encode(), json.dumps(payload).encode(), hashlib.sha256).hexdigest()
+        with mock.patch(
+            "odoo.addons.bibind_core.models.api_client.ApiClient.resolve_secret_ref",
+            return_value=secret,
+        ):
+            resp = self.url_open(
+                "/bibind/webhook/audit",
+                data=json.dumps(payload),
+                method="POST",
+                headers=self._headers(sig),
+            )
+        assert resp.json()["status"] == "ok"
+
+    def test_correlation_id_propagation(self):
+        payload = {
+            "correlation_id": "cid",
+            "event": "e",
+            "subject": "s",
+            "instance_id": "i",
+            "at": "now",
+        }
+
+        captured = {}
+
+        def fake_get_param(self, key, default=None):
+            captured["cid"] = self.env.context.get("correlation_id")
+            return None
+
+        with mock.patch(
+            "odoo.addons.bibind_core.models.settings.ParamStore.get_param",
+            new=fake_get_param,
+        ):
+            self.url_open(
+                "/bibind/webhook/audit",
+                data=json.dumps(payload),
+                method="POST",
+                headers=self._headers(),
+            )
+        assert captured["cid"] == "cid"
+
+    def test_bad_payload_returns_400(self):
+        resp = self.url_open(
+            "/bibind/webhook/audit",
+            data=json.dumps({"correlation_id": "x"}),
+            method="POST",
+            headers=self._headers(),
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- test ApiClient token refresh, retry logic and circuit breaker behavior
- add cross-tenant security rule test with PceMixin dummy model
- cover webhook HMAC validation, correlation id propagation and invalid payloads

## Testing
- `pytest partenaires/bibind_core/tests/test_api_client.py partenaires/bibind_core/tests/test_security_rules.py partenaires/bibind_core/tests/test_webhooks.py` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_68a6f925d2988325baae368192ff8522