### PR TITLE
feat(portal): add environment action endpoints with JSON logging

### DIFF
--- a/partenaires/bibind_portal/controllers/portal.py
+++ b/partenaires/bibind_portal/controllers/portal.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import json
 import logging
+import time
 
 from odoo import http
+from odoo.exceptions import UserError
+from odoo.http import request
 from odoo.addons.portal.controllers.portal import CustomerPortal
 
 _logger = logging.getLogger(__name__)
@@ -11,25 +15,93 @@ _logger = logging.getLogger(__name__)
 class BibindCustomerPortal(CustomerPortal):
     """Portal pages for Bibind services."""
 
+    # ------------------------------------------------------------------
+    def _json_log(self, started: float) -> None:
+        """Log request metadata in JSON."""
+        elapsed = int((time.time() - started) * 1000)
+        data = {
+            "user": request.env.user.id,
+            "tenant": request.env.company.id,
+            "path": request.httprequest.path,
+            "correlation_id": request.env.context.get("correlation_id"),
+            "elapsed_ms": elapsed,
+        }
+        _logger.info(json.dumps(data))
+
+    # ------------------------------------------------------------------
     @http.route("/my/home", type="http", auth="user", website=True)
     def home(self, **kw):
-        services = http.request.env["kb.service"].sudo().search([])
-        values = self._prepare_portal_layout_values()
-        values.update({"services": services})
-        return http.request.render("bibind_portal.portal_home", values)
+        started = time.time()
+        try:
+            services = request.env["kb.service"].sudo().search([])
+            values = self._prepare_portal_layout_values()
+            values.update({"services": services})
+            return request.render("bibind_portal.portal_home", values)
+        finally:
+            self._json_log(started)
 
     @http.route("/my/services", type="http", auth="user", website=True)
     def services(self, **kw):
-        services = http.request.env["kb.service"].sudo().search([])
-        values = self._prepare_portal_layout_values()
-        values.update({"services": services})
-        return http.request.render("bibind_portal.portal_services", values)
+        started = time.time()
+        try:
+            services = request.env["kb.service"].sudo().search([])
+            values = self._prepare_portal_layout_values()
+            values.update({"services": services})
+            return request.render("bibind_portal.portal_services", values)
+        finally:
+            self._json_log(started)
 
     @http.route("/my/services/<int:service_id>", type="http", auth="user", website=True)
     def service_detail(self, service_id: int, **kw):
-        service = http.request.env["kb.service"].sudo().browse(service_id)
-        if not service.exists():
-            return http.request.not_found()
-        values = self._prepare_portal_layout_values()
-        values.update({"service": service})
-        return http.request.render("bibind_portal.portal_service_detail", values)
+        started = time.time()
+        try:
+            service = request.env["kb.service"].sudo().browse(service_id)
+            if not service.exists():
+                return request.not_found()
+            values = self._prepare_portal_layout_values()
+            values.update({"service": service})
+            return request.render("bibind_portal.portal_service_detail", values)
+        finally:
+            self._json_log(started)
+
+    # ------------------------------------------------------------------
+    def _env_action(self, env_id: int, verb: str):
+        started = time.time()
+        try:
+            env = request.env["kb.environment"].sudo().browse(env_id)
+            action = getattr(env, f"do_{verb}", None)
+            if not env.exists() or not action:
+                return request.make_json_response({"error": "not found"}, status=404)
+            action()
+            return request.make_json_response({"status": "ok"})
+        except UserError as exc:
+            return request.make_json_response({"error": str(exc)}, status=400)
+        finally:
+            self._json_log(started)
+
+    @http.route(
+        "/my/environments/<int:env_id>/start",
+        type="json",
+        auth="user",
+        methods=["POST"],
+    )
+    def env_start(self, env_id: int):
+        return self._env_action(env_id, "start")
+
+    @http.route(
+        "/my/environments/<int:env_id>/stop",
+        type="json",
+        auth="user",
+        methods=["POST"],
+    )
+    def env_stop(self, env_id: int):
+        return self._env_action(env_id, "stop")
+
+    @http.route(
+        "/my/environments/<int:env_id>/promote",
+        type="json",
+        auth="user",
+        methods=["POST"],
+    )
+    def env_promote(self, env_id: int):
+        return self._env_action(env_id, "promote")


### PR DESCRIPTION
## Summary
- extend portal controller with JSON logging and correlation tracking
- add POST endpoints for environment start/stop/promote actions
- handle user errors consistently in JSON responses

## Testing
- `python -m black --check partenaires/bibind_portal/controllers/portal.py`
- `python -m flake8 partenaires/bibind_portal/controllers/portal.py` *(fails: No module named flake8)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `pytest` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fe09cf5c832587c3792ec712d30f