### PR TITLE
Add orchestrator wizards for service and environment

### DIFF
--- a/partenaires/bibind_portal/__init__.py
+++ b/partenaires/bibind_portal/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import controllers
+from . import wizards

--- a/partenaires/bibind_portal/__manifest__.py
+++ b/partenaires/bibind_portal/__manifest__.py
@@ -1,14 +1,15 @@
 {
-    'name': 'Bibind Portal',
-    'version': '0.1',
-    'summary': 'Customer portal for managing services',
-    'author': 'Bibind',
-    'depends': ['portal', 'web', 'mail', 'bus', 'bibind_core'],
-    'data': [
-        'security/ir.model.access.csv',
-        'security/rules.xml',
-        'views/portal_menu.xml',
+    "name": "Bibind Portal",
+    "version": "0.1",
+    "summary": "Customer portal for managing services",
+    "author": "Bibind",
+    "depends": ["portal", "web", "mail", "bus", "bibind_core"],
+    "data": [
+        "security/ir.model.access.csv",
+        "security/rules.xml",
+        "views/portal_menu.xml",
+        "views/wizards.xml",
     ],
-    'application': False,
-    'installable': True,
+    "application": False,
+    "installable": True,
 }

--- a/partenaires/bibind_portal/views/wizards.xml
+++ b/partenaires/bibind_portal/views/wizards.xml
@@ -1,0 +1,84 @@
+<odoo>
+    <!-- Create Service Wizard -->
+    <record id="view_create_service_wizard" model="ir.ui.view">
+        <field name="name">kb.create.service.wizard.form</field>
+        <field name="model">kb.create.service.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Create Service">
+                <group>
+                    <field name="name"/>
+                    <field name="offer"/>
+                    <field name="plan"/>
+                    <field name="sla"/>
+                </group>
+                <footer>
+                    <button name="action_create" string="Create" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_create_service_wizard" model="ir.actions.act_window">
+        <field name="name">Create Service</field>
+        <field name="res_model">kb.create.service.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_create_service_wizard"/>
+        <field name="target">new</field>
+    </record>
+
+    <!-- Create Environment Wizard -->
+    <record id="view_create_environment_wizard" model="ir.ui.view">
+        <field name="name">kb.create.environment.wizard.form</field>
+        <field name="model">kb.create.environment.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Create Environment">
+                <group>
+                    <field name="service_id"/>
+                    <field name="env"/>
+                    <field name="region"/>
+                    <field name="cluster"/>
+                    <field name="namespace"/>
+                </group>
+                <footer>
+                    <button name="action_create" string="Create" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_create_environment_wizard" model="ir.actions.act_window">
+        <field name="name">Create Environment</field>
+        <field name="res_model">kb.create.environment.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_create_environment_wizard"/>
+        <field name="target">new</field>
+    </record>
+
+    <!-- Post Deploy Wizard -->
+    <record id="view_post_deploy_wizard" model="ir.ui.view">
+        <field name="name">kb.post.deploy.wizard.form</field>
+        <field name="model">kb.post.deploy.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Post Deploy">
+                <group>
+                    <field name="environment_id"/>
+                    <field name="ref"/>
+                </group>
+                <footer>
+                    <button name="action_post_deploy" string="Send" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_post_deploy_wizard" model="ir.actions.act_window">
+        <field name="name">Post Deploy</field>
+        <field name="res_model">kb.post.deploy.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_post_deploy_wizard"/>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/partenaires/bibind_portal/wizards/__init__.py
+++ b/partenaires/bibind_portal/wizards/__init__.py
@@ -1,0 +1,3 @@
+from . import create_service_wizard
+from . import create_environment_wizard
+from . import post_deploy_wizard

--- a/partenaires/bibind_portal/wizards/create_environment_wizard.py
+++ b/partenaires/bibind_portal/wizards/create_environment_wizard.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Dict
+
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class CreateEnvironmentWizard(models.TransientModel):
+    """Wizard to create a new environment for a service."""
+
+    _name = "kb.create.environment.wizard"
+    _description = "Create Environment Wizard"
+
+    service_id = fields.Many2one("kb.service", required=True)
+    env = fields.Selection(
+        [
+            ("dev", "Dev"),
+            ("stage", "Stage"),
+            ("prod", "Prod"),
+            ("custom", "Custom"),
+        ],
+        required=True,
+    )
+    region = fields.Char()
+    cluster = fields.Char()
+    namespace = fields.Char()
+    correlation_id = fields.Char(default=lambda self: str(uuid.uuid4()))
+
+    @api.constrains("service_id", "env")
+    def _check_unique_env(self):
+        for wiz in self:
+            existing = self.env["kb.environment"].search(
+                [
+                    ("service_id", "=", wiz.service_id.id),
+                    ("env", "=", wiz.env),
+                ],
+                limit=1,
+            )
+            if existing:
+                raise UserError("Environment already exists for this service")
+
+    def _build_payload(self) -> Dict[str, object]:
+        return {
+            "env": self.env,
+            "region": self.region,
+            "cluster": self.cluster,
+            "namespace": self.namespace,
+        }
+
+    def action_create(self):
+        self.ensure_one()
+        payload = self._build_payload()
+        _logger.info(
+            "create environment",
+            extra={
+                "payload": payload,
+                "service": self.service_id.id,
+                "correlation_id": self.correlation_id,
+            },
+        )
+        client = self.env["bibind.api_client"].with_context(
+            correlation_id=self.correlation_id
+        )
+        client.create_environment(str(self.service_id.id), payload)
+        env = self.env["kb.environment"].create(
+            {
+                "service_id": self.service_id.id,
+                "env": self.env,
+                "region": self.region,
+                "cluster": self.cluster,
+                "namespace": self.namespace,
+            }
+        )
+        env.message_post(body=f"Environment created ({self.correlation_id})")
+        return {"type": "ir.actions.act_window_close"}

--- a/partenaires/bibind_portal/wizards/create_service_wizard.py
+++ b/partenaires/bibind_portal/wizards/create_service_wizard.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Dict
+
+from odoo import fields, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class CreateServiceWizard(models.TransientModel):
+    """Wizard to create a new service through the orchestrator."""
+
+    _name = "kb.create.service.wizard"
+    _description = "Create Service Wizard"
+
+    name = fields.Char(required=True)
+    offer = fields.Selection(
+        [
+            ("ecom", "E-com"),
+            ("iot", "IoT"),
+            ("lms", "LMS"),
+        ],
+        required=True,
+    )
+    plan = fields.Char()
+    sla = fields.Selection(
+        [
+            ("standard", "Standard"),
+            ("premium", "Premium"),
+            ("enterprise", "Enterprise"),
+        ]
+    )
+    correlation_id = fields.Char(default=lambda self: str(uuid.uuid4()))
+
+    def _build_payload(self) -> Dict[str, object]:
+        return {
+            "name": self.name,
+            "offer": self.offer,
+            "plan": self.plan,
+            "sla": self.sla,
+        }
+
+    def action_create(self):
+        self.ensure_one()
+        if self.env["kb.service"].search([("name", "=", self.name)], limit=1):
+            raise UserError("Service already exists")
+        payload = self._build_payload()
+        _logger.info(
+            "create service",
+            extra={"payload": payload, "correlation_id": self.correlation_id},
+        )
+        client = self.env["bibind.api_client"].with_context(
+            correlation_id=self.correlation_id
+        )
+        client.create_service(payload)
+        service = self.env["kb.service"].create(payload)
+        service.message_post(body=f"Service created ({self.correlation_id})")
+        return {"type": "ir.actions.act_window_close"}

--- a/partenaires/bibind_portal/wizards/post_deploy_wizard.py
+++ b/partenaires/bibind_portal/wizards/post_deploy_wizard.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Dict
+
+from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class PostDeployWizard(models.TransientModel):
+    """Wizard to trigger post-deploy actions."""
+
+    _name = "kb.post.deploy.wizard"
+    _description = "Post Deploy Wizard"
+
+    environment_id = fields.Many2one("kb.environment", required=True)
+    ref = fields.Char(required=True)
+    correlation_id = fields.Char(default=lambda self: str(uuid.uuid4()))
+
+    def _build_payload(self) -> Dict[str, object]:
+        return {"ref": self.ref}
+
+    def action_post_deploy(self):
+        self.ensure_one()
+        payload = self._build_payload()
+        _logger.info(
+            "post deploy",
+            extra={
+                "env": self.environment_id.id,
+                "payload": payload,
+                "correlation_id": self.correlation_id,
+            },
+        )
+        client = self.env["bibind.api_client"].with_context(
+            correlation_id=self.correlation_id
+        )
+        client.post_deploy(str(self.environment_id.id), payload)
+        self.environment_id.message_post(
+            body=f"Post deploy triggered ({self.correlation_id})"
+        )
+        return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
## Summary
- add transient wizards to create services and environments with orchestration calls
- expose post-deploy wizard and related forms

## Testing
- `black --check partenaires/bibind_portal/wizards/create_service_wizard.py partenaires/bibind_portal/wizards/create_environment_wizard.py partenaires/bibind_portal/wizards/post_deploy_wizard.py partenaires/bibind_portal/wizards/__init__.py partenaires/bibind_portal/__init__.py partenaires/bibind_portal/__manifest__.py`
- `pip install flake8` *(failed: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(errors: ModuleNotFoundError: No module named 'app', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fe03afe08325af8f108341800dc9