### PR TITLE
Add portal tests for services, deployments and costs

### DIFF
--- a/partenaires/bibind_portal/tests/test_costs.py
+++ b/partenaires/bibind_portal/tests/test_costs.py
@@ -1,0 +1,29 @@
+from unittest import mock
+from decimal import Decimal
+
+from odoo.tests.common import TransactionCase
+
+
+class CostEstimateCase(TransactionCase):
+    """Ensure costs are updated via ApiClient."""
+
+    def setUp(self):
+        super().setUp()
+        Tenant = self.env['pce.tenant']
+        self.tenant = Tenant.create({'name': 'Tenant'})
+        Service = self.env['kb.service']
+        self.service = Service.create({'name': 'S1', 'tenant_id': self.tenant.id})
+        Env = self.env['kb.environment']
+        self.env1 = Env.create({'service_id': self.service.id, 'env': 'dev', 'tenant_id': self.tenant.id})
+
+    def test_refresh_all_for_service(self):
+        with mock.patch('odoo.addons.bibind_core.services.api_client.ApiClient.from_env') as mock_cli:
+            fake_client = mock.Mock()
+            fake_client.get.return_value = {'amount': 12.5}
+            mock_cli.return_value = fake_client
+            estimator = self.env['kb.cost.estimate']
+            amounts = estimator.refresh_all_for_service(self.service)
+            assert amounts[self.env1.id] == Decimal('12.5')
+            self.env1.refresh()
+            assert self.env1.cost_estimate == Decimal('12.5')
+            fake_client.get.assert_called_once_with(f'/environments/{self.env1.id}/costs:estimate')

--- a/partenaires/bibind_portal/tests/test_service_flows.py
+++ b/partenaires/bibind_portal/tests/test_service_flows.py
@@ -1,0 +1,50 @@
+from unittest import mock
+
+from odoo.tests.common import HttpCase
+
+
+class ServiceFlowsCase(HttpCase):
+    """Cover portal routes and security for services."""
+
+    def setUp(self):
+        super().setUp()
+        Tenant = self.env['pce.tenant']
+        self.tenant1 = Tenant.create({'name': 'Tenant A'})
+        self.tenant2 = Tenant.create({'name': 'Tenant B'})
+        User = self.env['res.users'].with_context(no_reset_password=True)
+        portal_group = self.env.ref('base.group_portal')
+        self.user1 = User.create({'name': 'U1', 'login': 'u1', 'password': 'pwd1', 'tenant_id': self.tenant1.id})
+        self.user1.groups_id = [(6, 0, [portal_group.id])]
+        self.user2 = User.create({'name': 'U2', 'login': 'u2', 'password': 'pwd2', 'tenant_id': self.tenant2.id})
+        self.user2.groups_id = [(6, 0, [portal_group.id])]
+        Service = self.env['kb.service']
+        self.s1 = Service.create({'name': 'S1', 'tenant_id': self.tenant1.id})
+        self.s2 = Service.create({'name': 'S2', 'tenant_id': self.tenant2.id})
+        Env = self.env['kb.environment']
+        self.env1 = Env.create({'service_id': self.s1.id, 'env': 'dev', 'tenant_id': self.tenant1.id})
+        self.env2 = Env.create({'service_id': self.s2.id, 'env': 'dev', 'tenant_id': self.tenant2.id})
+
+    def test_routes_and_security(self):
+        """Ensure portal routes enforce authentication and security."""
+        resp = self.url_open('/my/services', allow_redirects=False)
+        assert resp.status_code == 302
+        self.authenticate('u1', 'pwd1')
+        resp = self.url_open('/my/services')
+        assert resp.status_code == 200
+        resp = self.url_open(f'/my/services/{self.s2.id}')
+        assert resp.status_code == 404
+
+    def test_api_proxy(self):
+        """Monitoring and log signurl endpoints use ApiClient."""
+        self.authenticate('u1', 'pwd1')
+        with mock.patch('odoo.addons.bibind_core.services.api_client.ApiClient.from_env') as mock_cli:
+            fake_client = mock.Mock()
+            fake_client.get.return_value = {'url': 'http://m'}
+            mock_cli.return_value = fake_client
+            resp = self.url_open(
+                f'/my/api/monitoring/signurl/{self.env1.id}',
+                method='GET',
+                headers={'Content-Type': 'application/json'},
+            )
+            assert resp.json()['url'] == 'http://m'
+            fake_client.get.assert_called_once_with(f'/environments/{self.env1.id}/monitoring:link')

--- a/partenaires/bibind_portal/tests/test_wizards.py
+++ b/partenaires/bibind_portal/tests/test_wizards.py
@@ -1,0 +1,35 @@
+from unittest import mock
+
+from odoo.tests.common import TransactionCase
+from odoo.addons.bibind_core.services.api_client import ApiClient
+
+
+class WizardFlowsCase(TransactionCase):
+    """Validate environment command flows creating deployments."""
+
+    def setUp(self):
+        super().setUp()
+        Tenant = self.env['pce.tenant']
+        self.tenant = Tenant.create({'name': 'Tenant'})
+        Service = self.env['kb.service']
+        self.service = Service.create({'name': 'S1', 'tenant_id': self.tenant.id})
+        Env = self.env['kb.environment']
+        self.env1 = Env.create({'service_id': self.service.id, 'env': 'dev', 'tenant_id': self.tenant.id})
+
+    def test_start_creates_deployment(self):
+        def fake_run(self, env_id, verb, payload=None, headers=None):
+            client = ApiClient.from_env(self.env)
+            client.post('/deployments', json={'environment': env_id, 'action': verb})
+            self.env['kb.deployment'].create({'environment_id': env_id, 'action': verb})
+            return {}
+
+        with mock.patch('odoo.addons.bibind_portal.models.environment.ServiceOrchestrator.run', new=fake_run):
+            with mock.patch('odoo.addons.bibind_core.services.api_client.ApiClient.from_env') as mock_cli:
+                fake_client = mock.Mock()
+                mock_cli.return_value = fake_client
+                fake_client.post.return_value = {'id': 1}
+                self.env1.do_start()
+                fake_client.post.assert_called_once_with('/deployments', json={'environment': self.env1.id, 'action': 'start'})
+
+        dep = self.env['kb.deployment'].search([('environment_id', '=', self.env1.id), ('action', '=', 'start')])
+        assert dep


### PR DESCRIPTION
## Summary
- test portal service routes and ApiClient proxy helpers
- verify environment commands record deployments via mocked ApiClient
- ensure cost estimator refreshes service costs using ApiClient

## Testing
- `pytest tests/test_service_flows.py tests/test_wizards.py tests/test_costs.py -q` *(fails: ModuleNotFoundError: No module named 'odoo')*


------
https://chatgpt.com/codex/tasks/task_e_68a7011063b083259d4964c71d023553