### PR TITLE
feat(portal_projects): add project creation wizard

### DIFF
--- a/partenaires/bibind_portal_projects/__init__.py
+++ b/partenaires/bibind_portal_projects/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import controllers
+from . import wizards

--- a/partenaires/bibind_portal_projects/__manifest__.py
+++ b/partenaires/bibind_portal_projects/__manifest__.py
@@ -15,6 +15,7 @@
         'views/billing_views.xml',
         'views/studio_views.xml',
         'views/sync_views.xml',
+        'views/project_wizard_views.xml',
     ],
     'demo': ['data/demo.xml'],
     'installable': True,

--- a/partenaires/bibind_portal_projects/controllers/projects.py
+++ b/partenaires/bibind_portal_projects/controllers/projects.py
@@ -8,6 +8,15 @@ class ProjectPortal(http.Controller):
         projects = request.env['project.project'].sudo().search([])
         return request.render('bibind_portal_projects.projects_portal', {'projects': projects})
 
+    @http.route('/my/projects/new', auth='user', website=True)
+    def create_project(self, **kw):
+        action = (
+            request.env.ref("bibind_portal_projects.action_project_create_wizard")
+            .sudo()
+            .read()[0]
+        )
+        return request.redirect(f"/web#action={action['id']}")
+
     @http.route('/my/projects/<int:project_id>/sync', auth='user', website=True)
     def sync_project(self, project_id, **kw):
         project = request.env['project.project'].sudo().browse(project_id)

--- a/partenaires/bibind_portal_projects/models/project_link.py
+++ b/partenaires/bibind_portal_projects/models/project_link.py
@@ -1,4 +1,5 @@
 from odoo import _, api, fields, models
+from odoo.exceptions import RedirectWarning
 
 
 class Project(models.Model):
@@ -24,7 +25,14 @@ class Project(models.Model):
     def _check_service(self):
         for project in self:
             if not project.service_id:
-                raise models.ValidationError(_('A service is required for every project.'))
+                action = project.env.ref(
+                    "bibind_portal_projects.action_project_create_wizard"
+                )
+                raise RedirectWarning(
+                    _('A service is required for every project.'),
+                    action.id,
+                    _('Select or create a service'),
+                )
 
     def action_open_service(self):
         self.ensure_one()

--- a/partenaires/bibind_portal_projects/views/project_wizard_views.xml
+++ b/partenaires/bibind_portal_projects/views/project_wizard_views.xml
@@ -1,0 +1,26 @@
+<odoo>
+    <record id="view_project_create_wizard" model="ir.ui.view">
+        <field name="name">kb.project.create.wizard.form</field>
+        <field name="model">kb.project.create.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Create Project">
+                <group>
+                    <field name="name"/>
+                    <field name="service_id"/>
+                </group>
+                <footer>
+                    <button name="action_next" string="Next" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_project_create_wizard" model="ir.actions.act_window">
+        <field name="name">Create Project</field>
+        <field name="res_model">kb.project.create.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_project_create_wizard"/>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/partenaires/bibind_portal_projects/wizards/__init__.py
+++ b/partenaires/bibind_portal_projects/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import project_create

--- a/partenaires/bibind_portal_projects/wizards/project_create.py
+++ b/partenaires/bibind_portal_projects/wizards/project_create.py
@@ -1,0 +1,29 @@
+from odoo import fields, models
+
+
+class ProjectCreateWizard(models.TransientModel):
+    """Wizard helping to select or create a service before creating a project."""
+
+    _name = "kb.project.create.wizard"
+    _description = "Project Create Wizard"
+
+    name = fields.Char(required=True)
+    service_id = fields.Many2one("kb.service")
+
+    def action_next(self):
+        """Create the project or redirect to service creation wizard."""
+        self.ensure_one()
+        if not self.service_id:
+            action = self.env.ref("bibind_portal.action_create_service_wizard").read()[0]
+            action.setdefault("context", {})["default_name"] = self.name
+            return action
+        project = self.env["project.project"].create(
+            {"name": self.name, "service_id": self.service_id.id}
+        )
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "project.project",
+            "res_id": project.id,
+            "view_mode": "form",
+            "target": "current",
+        }


### PR DESCRIPTION
## Summary
- add wizard to select or create a service when starting a new project
- expose `/my/projects/new` route to trigger the wizard
- ensure missing service constraint launches wizard instead of error

## Testing
- `python -m py_compile partenaires/bibind_portal_projects/controllers/projects.py partenaires/bibind_portal_projects/models/project_link.py partenaires/bibind_portal_projects/wizards/project_create.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo')*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8 (ProxyError))*

------
https://chatgpt.com/codex/tasks/task_e_68a704ec5de48325a75b92debef55fa6