### PR TITLE
feat(portal-projects): add project portal routes

### DIFF
--- a/partenaires/bibind_portal_projects/controllers/projects.py
+++ b/partenaires/bibind_portal_projects/controllers/projects.py
@@ -3,13 +3,22 @@ from odoo.http import request
 
 
 class ProjectPortal(http.Controller):
-    @http.route('/my/projects', auth='user', website=True)
-    def list_projects(self, **kw):
-        projects = request.env['project.project'].sudo().search([])
-        return request.render('bibind_portal_projects.projects_portal', {'projects': projects})
+    """Website portal for project-related pages."""
 
-    @http.route('/my/projects/new', auth='user', website=True)
+    # ------------------------------------------------------------------
+    # Project listing and creation
+    # ------------------------------------------------------------------
+    @http.route("/my/projects", auth="user", website=True)
+    def list_projects(self, **kw):
+        """Display all projects for the current user."""
+        projects = request.env["project.project"].sudo().search([])
+        return request.render(
+            "bibind_portal_projects.projects_portal", {"projects": projects}
+        )
+
+    @http.route("/my/projects/new", auth="user", website=True)
     def create_project(self, **kw):
+        """Open the project creation wizard."""
         action = (
             request.env.ref("bibind_portal_projects.action_project_create_wizard")
             .sudo()
@@ -17,8 +26,55 @@ class ProjectPortal(http.Controller):
         )
         return request.redirect(f"/web#action={action['id']}")
 
-    @http.route('/my/projects/<int:project_id>/sync', auth='user', website=True)
-    def sync_project(self, project_id, **kw):
-        project = request.env['project.project'].sudo().browse(project_id)
-        project.action_sync_gitlab()
-        return request.redirect('/my/projects')
+    # ------------------------------------------------------------------
+    # Project details
+    # ------------------------------------------------------------------
+    @http.route("/my/projects/<int:project_id>", auth="user", website=True)
+    def project_detail(self, project_id: int, **kw):
+        """Display details of a single project."""
+        project = request.env["project.project"].sudo().browse(project_id)
+        if not project.exists():
+            return request.not_found()
+        return request.render(
+            "bibind_portal_projects.project_portal_detail", {"project": project}
+        )
+
+    # ------------------------------------------------------------------
+    # Asynchronous actions
+    # ------------------------------------------------------------------
+    @http.route("/my/projects/<int:project_id>/sync", auth="user", website=True)
+    def sync_project(self, project_id: int, **kw):
+        """Trigger an asynchronous synchronization with GitLab."""
+        request.env["kb.projects.facade"].sudo().with_context(
+            project_id=project_id
+        ).sync_gitlab()
+        return request.redirect(f"/my/projects/{project_id}")
+
+    @http.route("/my/projects/<int:project_id>/sprints/new", auth="user", website=True)
+    def sprint_new(self, project_id: int, **kw):
+        """Open the sprint planning wizard for the project."""
+        try:
+            action = (
+                request.env.ref("bibind_portal_projects.action_sprint_plan_wizard")
+                .sudo()
+                .read()[0]
+            )
+        except Exception:  # pragma: no cover - defensive
+            return request.redirect(
+                f"/web#id={project_id}&model=project.project&view_type=form"
+            )
+        action["context"] = {"default_project_id": project_id}
+        return request.redirect(f"/web#action={action['id']}")
+
+    @http.route(
+        "/my/projects/<int:project_id>/studio/ai",
+        type="json",
+        auth="user",
+        methods=["POST"],
+    )
+    def studio_ai(self, project_id: int, **kw):
+        """Launch a simple AI task for the project via the facade."""
+        request.env["kb.projects.facade"].sudo().with_context(
+            project_id=project_id
+        ).run_studio_ai()
+        return {"status": "ok"}

--- a/partenaires/bibind_portal_projects/models/orchestrators.py
+++ b/partenaires/bibind_portal_projects/models/orchestrators.py
@@ -74,3 +74,15 @@ class ProjectsFacade(models.Model):
             self._release_lock(project_id)
 
         return True
+
+    @api.model
+    def run_studio_ai(self):
+        """Run a simple Studio AI task for the given project."""
+        project_id = self.env.context.get("project_id")
+        if not project_id:
+            return False
+        task = self.env["kb.studio.ai"].create(
+            {"project_id": project_id, "name": "Studio AI"}
+        )
+        task.run_task()
+        return True


### PR DESCRIPTION
## Summary
- add website controllers for project list, detail and management
- use kb.projects.facade for GitLab sync and AI tasks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo')*
- `pytest partenaires/bibind_portal_projects/tests/test_projects_sync.py -q` *(fails: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_68a709d604f883258d6f50882bbfdbe6