### PR TITLE
Restrict project access by group and tenant

### DIFF
--- a/partenaires/bibind_portal_projects/data/res_groups.xml
+++ b/partenaires/bibind_portal_projects/data/res_groups.xml
@@ -2,12 +2,15 @@
     <data noupdate="1">
         <record id="group_project_viewer" model="res.groups">
             <field name="name">Project Viewer</field>
+            <field name="implied_ids" eval="[(4, ref('bibind_core.group_bibind_customer_admin'))]"/>
         </record>
         <record id="group_project_member" model="res.groups">
             <field name="name">Project Member</field>
+            <field name="implied_ids" eval="[(4, ref('bibind_portal_projects.group_project_viewer'))]"/>
         </record>
         <record id="group_project_admin" model="res.groups">
             <field name="name">Project Admin</field>
+            <field name="implied_ids" eval="[(4, ref('bibind_portal_projects.group_project_member'))]"/>
         </record>
     </data>
 </odoo>

--- a/partenaires/bibind_portal_projects/security/ir.model.access.csv
+++ b/partenaires/bibind_portal_projects/security/ir.model.access.csv
@@ -1,7 +1,25 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_project_budget,access_project_budget,model_kb_project_budget,base.group_user,1,1,1,1
-access_budget_line,access_budget_line,model_kb_budget_line,base.group_user,1,1,1,1
-access_project_milestone,access_project_milestone,model_kb_project_milestone,base.group_user,1,1,1,1
-access_project_doc,access_project_doc,model_kb_project_doc,base.group_user,1,1,1,1
-access_studio_ai,access_studio_ai,model_kb_studio_ai,base.group_user,1,1,1,1
-access_sprint,access_sprint,model_kb_sprint,base.group_user,1,1,1,1
+# Project budgets
+access_project_budget_viewer,project budget viewer,model_kb_project_budget,bibind_portal_projects.group_project_viewer,1,0,0,0
+access_project_budget_member,project budget member,model_kb_project_budget,bibind_portal_projects.group_project_member,1,1,1,0
+access_project_budget_admin,project budget admin,model_kb_project_budget,bibind_portal_projects.group_project_admin,1,1,1,1
+# Budget lines
+access_budget_line_viewer,budget line viewer,model_kb_budget_line,bibind_portal_projects.group_project_viewer,1,0,0,0
+access_budget_line_member,budget line member,model_kb_budget_line,bibind_portal_projects.group_project_member,1,1,1,0
+access_budget_line_admin,budget line admin,model_kb_budget_line,bibind_portal_projects.group_project_admin,1,1,1,1
+# Project milestones
+access_project_milestone_viewer,project milestone viewer,model_kb_project_milestone,bibind_portal_projects.group_project_viewer,1,0,0,0
+access_project_milestone_member,project milestone member,model_kb_project_milestone,bibind_portal_projects.group_project_member,1,1,1,0
+access_project_milestone_admin,project milestone admin,model_kb_project_milestone,bibind_portal_projects.group_project_admin,1,1,1,1
+# Project docs
+access_project_doc_viewer,project doc viewer,model_kb_project_doc,bibind_portal_projects.group_project_viewer,1,0,0,0
+access_project_doc_member,project doc member,model_kb_project_doc,bibind_portal_projects.group_project_member,1,1,1,0
+access_project_doc_admin,project doc admin,model_kb_project_doc,bibind_portal_projects.group_project_admin,1,1,1,1
+# Studio AI
+access_studio_ai_viewer,studio ai viewer,model_kb_studio_ai,bibind_portal_projects.group_project_viewer,1,0,0,0
+access_studio_ai_member,studio ai member,model_kb_studio_ai,bibind_portal_projects.group_project_member,1,1,1,0
+access_studio_ai_admin,studio ai admin,model_kb_studio_ai,bibind_portal_projects.group_project_admin,1,1,1,1
+# Sprints
+access_sprint_viewer,sprint viewer,model_kb_sprint,bibind_portal_projects.group_project_viewer,1,0,0,0
+access_sprint_member,sprint member,model_kb_sprint,bibind_portal_projects.group_project_member,1,1,1,0
+access_sprint_admin,sprint admin,model_kb_sprint,bibind_portal_projects.group_project_admin,1,1,1,1

--- a/partenaires/bibind_portal_projects/security/rules.xml
+++ b/partenaires/bibind_portal_projects/security/rules.xml
@@ -1,9 +1,32 @@
 <odoo>
-    <data noupdate="1">
-        <record id="project_rule_user" model="ir.rule">
-            <field name="name">Project tenant rule</field>
-            <field name="model_id" ref="project.model_project_project"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
-        </record>
-    </data>
+    <record id="project_tenant_rule" model="ir.rule">
+        <field name="name">Project tenant access</field>
+        <field name="model_id" ref="project.model_project_project"/>
+        <field name="domain_force">['|',('service_id.tenant_id','=',user.tenant_id.id),('service_id.tenant_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('bibind_portal_projects.group_project_viewer'))]"/>
+    </record>
+    <record id="task_tenant_rule" model="ir.rule">
+        <field name="name">Task tenant access</field>
+        <field name="model_id" ref="project.model_project_task"/>
+        <field name="domain_force">['|',('project_id.service_id.tenant_id','=',user.tenant_id.id),('project_id.service_id.tenant_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('bibind_portal_projects.group_project_viewer'))]"/>
+    </record>
+    <record id="project_budget_tenant_rule" model="ir.rule">
+        <field name="name">Project budget tenant access</field>
+        <field name="model_id" ref="model_kb_project_budget"/>
+        <field name="domain_force">['|',('project_id.service_id.tenant_id','=',user.tenant_id.id),('project_id.service_id.tenant_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('bibind_portal_projects.group_project_viewer'))]"/>
+    </record>
+    <record id="budget_line_tenant_rule" model="ir.rule">
+        <field name="name">Budget line tenant access</field>
+        <field name="model_id" ref="model_kb_budget_line"/>
+        <field name="domain_force">['|',('budget_id.project_id.service_id.tenant_id','=',user.tenant_id.id),('budget_id.project_id.service_id.tenant_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('bibind_portal_projects.group_project_viewer'))]"/>
+    </record>
+    <record id="project_milestone_tenant_rule" model="ir.rule">
+        <field name="name">Project milestone tenant access</field>
+        <field name="model_id" ref="model_kb_project_milestone"/>
+        <field name="domain_force">['|',('project_id.service_id.tenant_id','=',user.tenant_id.id),('project_id.service_id.tenant_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('bibind_portal_projects.group_project_viewer'))]"/>
+    </record>
 </odoo>


### PR DESCRIPTION
## Summary
- define viewer, member and admin project groups with hierarchical ACLs
- scope project models to groups with tailored access controls
- enforce tenant-based record rules on project, task, budget and milestone records

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68a70c19973c8325921abda77285d7b9