### PR TITLE
feat(portal-projects): add mail templates demo cron

### DIFF
--- a/partenaires/bibind_portal_projects/data/cron.xml
+++ b/partenaires/bibind_portal_projects/data/cron.xml
@@ -1,20 +1,22 @@
 <odoo>
     <data>
-        <record id="ir_cron_project_sync" model="ir.cron">
-            <field name="name">Project Sync</field>
+        <record id="ir_cron_issue_sync" model="ir.cron">
+            <field name="name">Issue Sync</field>
             <field name="model_id" ref="model_kb_projects_facade"/>
             <field name="state">code</field>
-            <field name="code">model.sync_gitlab()</field>
+            <field name="code">model.sync_issues()</field>
             <field name="interval_number">1</field>
             <field name="interval_type">hours</field>
         </record>
-        <record id="ir_cron_project_backlog_kpi" model="ir.cron">
-            <field name="name">Backlog &amp; KPI Refresh</field>
+
+        <record id="ir_cron_kpi_budget_refresh" model="ir.cron">
+            <field name="name">KPI &amp; Budget Refresh</field>
             <field name="model_id" ref="model_kb_projects_facade"/>
             <field name="state">code</field>
-            <field name="code">model.sync_gitlab()</field>
+            <field name="code">model.refresh_kpis_budget()</field>
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>
         </record>
     </data>
 </odoo>
+

--- a/partenaires/bibind_portal_projects/data/demo.xml
+++ b/partenaires/bibind_portal_projects/data/demo.xml
@@ -1,8 +1,18 @@
 <odoo>
     <data>
+        <record id="service_demo" model="kb.service">
+            <field name="name">Demo Service</field>
+        </record>
+
         <record id="project_demo" model="project.project">
             <field name="name">Demo Project</field>
-            <field name="service_id" ref="bibind_portal.service_demo"/>
+            <field name="service_id" ref="service_demo"/>
+        </record>
+
+        <record id="task_backlog_demo" model="project.task">
+            <field name="name">Initial backlog item</field>
+            <field name="project_id" ref="project_demo"/>
         </record>
     </data>
 </odoo>
+

--- a/partenaires/bibind_portal_projects/data/mail_templates.xml
+++ b/partenaires/bibind_portal_projects/data/mail_templates.xml
@@ -1,10 +1,34 @@
 <odoo>
-    <data>
-        <record id="mail_template_project_sync" model="mail.template">
-            <field name="name">Project Sync Notification</field>
+    <data noupdate="1">
+        <record id="mail_template_sprint_notification" model="mail.template">
+            <field name="name">Sprint Notification</field>
             <field name="model_id" ref="project.model_project_project"/>
-            <field name="subject">Project synchronized</field>
-            <field name="body_html"><![CDATA[<p>Your project has been synchronized.</p>]]></field>
+            <field name="subject">Sprint ${ctx.get('sprint_name', '')}</field>
+            <field name="body_html"><![CDATA[
+                <p>Hello ${object.user_id.name or ''},</p>
+                <p>The sprint <strong>${ctx.get('sprint_name', '')}</strong> for project <strong>${object.name}</strong> is now available.</p>
+            ]]></field>
+        </record>
+
+        <record id="mail_template_ai_notification" model="mail.template">
+            <field name="name">AI Notification</field>
+            <field name="model_id" ref="project.model_project_project"/>
+            <field name="subject">AI update for ${object.name}</field>
+            <field name="body_html"><![CDATA[
+                <p>Hello ${object.user_id.name or ''},</p>
+                <p>The AI processing for project <strong>${object.name}</strong> is complete.</p>
+            ]]></field>
+        </record>
+
+        <record id="mail_template_milestone_notification" model="mail.template">
+            <field name="name">Milestone Notification</field>
+            <field name="model_id" ref="project.model_project_project"/>
+            <field name="subject">Milestone reached for ${object.name}</field>
+            <field name="body_html"><![CDATA[
+                <p>Hello ${object.user_id.name or ''},</p>
+                <p>The milestone <strong>${ctx.get('milestone_name', '')}</strong> of project <strong>${object.name}</strong> has been reached.</p>
+            ]]></field>
         </record>
     </data>
 </odoo>
+


### PR DESCRIPTION
## Summary
- add mail templates for sprint, AI and milestone notifications
- provide demo data for service, project and backlog
- schedule crons for issue sync and KPI/budget refresh

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68a70c1be7a08325babcb731759f1c2b