### PR TITLE
feat: schedule and trigger gitlab sync

### DIFF
--- a/partenaires/bibind_portal_projects/controllers/__init__.py
+++ b/partenaires/bibind_portal_projects/controllers/__init__.py
@@ -1,1 +1,2 @@
 from . import projects
+from . import webhooks

--- a/partenaires/bibind_portal_projects/controllers/webhooks.py
+++ b/partenaires/bibind_portal_projects/controllers/webhooks.py
@@ -1,0 +1,21 @@
+from odoo import http
+from odoo.http import request
+
+
+class GitLabWebhook(http.Controller):
+    """Handle incoming GitLab webhooks."""
+
+    @http.route(
+        "/gitlab/<int:project_id>/webhook",
+        type="json",
+        auth="public",
+        methods=["POST"],
+        csrf=False,
+    )
+    def gitlab_webhook(self, project_id: int, **payload):
+        """Trigger a synchronization for the given *project_id*."""
+
+        request.env["kb.projects.facade"].sudo().with_context(
+            project_id=project_id
+        ).sync_gitlab()
+        return {"status": "ok"}

--- a/partenaires/bibind_portal_projects/models/orchestrators.py
+++ b/partenaires/bibind_portal_projects/models/orchestrators.py
@@ -109,6 +109,17 @@ class ProjectsFacade(models.Model):
 
         return True
 
+    @api.model
+    def sync_issues(self):
+        """Periodic job to synchronize all GitLab-backed projects."""
+
+        projects = self.env["project.project"].search([
+            ("gitlab_project_id", "!=", False)
+        ])
+        for project in projects:
+            self.with_context(project_id=project.id).sync_gitlab()
+        return True
+
 
     @api.model
     def run_studio_ai(self):


### PR DESCRIPTION
## Summary
- add webhook route to trigger GitLab sync
- periodically trigger GitLab sync for all projects

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68a72252c07c8325af91914a7cbfc824