### PR TITLE
feat(project): add backlog and sprint planning

### DIFF
--- a/partenaires/bibind_portal_projects/models/backlog.py
+++ b/partenaires/bibind_portal_projects/models/backlog.py
@@ -2,33 +2,53 @@ from odoo import api, fields, models
 
 
 class ProjectTask(models.Model):
-    _inherit = 'project.task'
+    _inherit = "project.task"
 
     gitlab_issue_id = fields.Integer(index=True)
     issue_type = fields.Selection(
         [
-            ('epic', 'Epic'),
-            ('story', 'Story'),
-            ('task', 'Task'),
-            ('bug', 'Bug'),
+            ("epic", "Epic"),
+            ("story", "Story"),
+            ("task", "Task"),
+            ("bug", "Bug"),
         ],
-        default='task',
+        default="task",
     )
     story_points = fields.Float()
-    sprint_id = fields.Many2one('kb.sprint')
+    sprint_id = fields.Many2one("kb.sprint")
+
+    # ------------------------------------------------------------------
+    # Issue mapping helpers
+    # ------------------------------------------------------------------
+    @api.model
+    def map_issue(self, issue):
+        """Create or update a task from a GitLab issue dict.
+
+        The method searches an existing task using ``gitlab_issue_id`` and
+        updates it in place.  If no task is found a new one is created.  The
+        returned record allows callers to easily keep a local reference when
+        syncing issues from GitLab.
+        """
+
+        task = self.search([("gitlab_issue_id", "=", issue.get("id"))], limit=1)
+        if task:
+            task.update_from_issue(issue)
+        else:
+            task = self.create_from_issue(issue)
+        return task
 
     @api.model
     def create_from_issue(self, issue):
         """Create a task from a GitLab issue dict."""
         vals = {
-            'name': issue.get('title'),
-            'description': issue.get('description'),
-            'gitlab_issue_id': issue.get('id'),
-            'issue_type': issue.get('type') or 'task',
-            'story_points': issue.get('story_points', 0.0),
+            "name": issue.get("title"),
+            "description": issue.get("description"),
+            "gitlab_issue_id": issue.get("id"),
+            "issue_type": issue.get("type") or "task",
+            "story_points": issue.get("story_points", 0.0),
         }
-        if issue.get('sprint_id'):
-            vals['sprint_id'] = issue['sprint_id']
+        if issue.get("sprint_id"):
+            vals["sprint_id"] = issue["sprint_id"]
         return self.create(vals)
 
     def update_from_issue(self, issue):
@@ -36,27 +56,41 @@ class ProjectTask(models.Model):
         vals = {
             k: v
             for k, v in {
-                'name': issue.get('title'),
-                'description': issue.get('description'),
-                'issue_type': issue.get('type'),
-                'story_points': issue.get('story_points'),
+                "name": issue.get("title"),
+                "description": issue.get("description"),
+                "issue_type": issue.get("type"),
+                "story_points": issue.get("story_points"),
             }.items()
             if v is not None
         }
-        if issue.get('sprint_id'):
-            vals['sprint_id'] = issue['sprint_id']
+        if issue.get("sprint_id"):
+            vals["sprint_id"] = issue["sprint_id"]
         if vals:
             self.write(vals)
         return True
+
+    # ------------------------------------------------------------------
+    # Story point synchronisation
+    # ------------------------------------------------------------------
+    def write(self, vals):
+        """Override to propagate story point changes back to GitLab."""
+
+        res = super().write(vals)
+        if "story_points" in vals:
+            sync = self.env["kb.sync.gitlab"]
+            for task in self.filtered("gitlab_issue_id"):
+                # push the updated task to GitLab to keep story points aligned
+                sync.push_tasks(task.project_id, task)
+        return res
 
     def to_issue_payload(self):
         """Return a dict payload representing the task for GitLab."""
         self.ensure_one()
         return {
-            'id': self.gitlab_issue_id,
-            'title': self.name,
-            'description': self.description,
-            'type': self.issue_type,
-            'story_points': self.story_points,
-            'sprint_id': self.sprint_id.id,
+            "id": self.gitlab_issue_id,
+            "title": self.name,
+            "description": self.description,
+            "type": self.issue_type,
+            "story_points": self.story_points,
+            "sprint_id": self.sprint_id.id,
         }

--- a/partenaires/bibind_portal_projects/views/project_views.xml
+++ b/partenaires/bibind_portal_projects/views/project_views.xml
@@ -61,5 +61,29 @@
                 </kanban>
             </field>
         </record>
+
+        <!-- Backlog board showing unsprinted stories for the project -->
+        <record id="view_task_backlog_board" model="ir.ui.view">
+            <field name="name">kb.project.task.backlog.board</field>
+            <field name="model">project.task</field>
+            <field name="arch" type="xml">
+                <kanban class="o_kb_backlog_kanban" create="false">
+                    <field name="name" invisible="1"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <t t-call="kb.BacklogBoard"/>
+                        </t>
+                    </templates>
+                </kanban>
+            </field>
+        </record>
+
+        <record id="action_project_backlog_board" model="ir.actions.act_window">
+            <field name="name">Backlog</field>
+            <field name="res_model">project.task</field>
+            <field name="view_mode">kanban</field>
+            <field name="view_id" ref="view_task_backlog_board"/>
+            <field name="context">{}</field>
+        </record>
     </data>
 </odoo>

--- a/partenaires/bibind_portal_projects/views/sprint_views.xml
+++ b/partenaires/bibind_portal_projects/views/sprint_views.xml
@@ -5,5 +5,31 @@
             <div class="o_kb_sprint_board"/>
         </t>
     </templates>
+
+    <data>
+        <!-- Sprint board using the generic sprint QWeb template -->
+        <record id="view_task_sprint_board" model="ir.ui.view">
+            <field name="name">kb.project.task.sprint.board</field>
+            <field name="model">project.task</field>
+            <field name="arch" type="xml">
+                <kanban class="o_kb_sprint_kanban" create="false">
+                    <field name="name" invisible="1"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <t t-call="kb.SprintBoard"/>
+                        </t>
+                    </templates>
+                </kanban>
+            </field>
+        </record>
+
+        <record id="action_task_sprint_board" model="ir.actions.act_window">
+            <field name="name">Sprint Board</field>
+            <field name="res_model">project.task</field>
+            <field name="view_mode">kanban</field>
+            <field name="view_id" ref="view_task_sprint_board"/>
+            <field name="context">{}</field>
+        </record>
+    </data>
 </odoo>
 

--- a/partenaires/bibind_portal_projects/wizards/sprint_plan.py
+++ b/partenaires/bibind_portal_projects/wizards/sprint_plan.py
@@ -2,33 +2,34 @@ from odoo import api, fields, models
 
 
 class SprintPlanWizard(models.TransientModel):
-    _name = 'kb.sprint.plan.wizard'
-    _description = 'Sprint Planning Wizard'
+    _name = "kb.sprint.plan.wizard"
+    _description = "Sprint Planning Wizard"
 
     project_id = fields.Many2one(
-        'project.project', required=True, default=lambda self: self.env.context.get('default_project_id')
+        "project.project",
+        required=True,
+        default=lambda self: self.env.context.get("default_project_id"),
     )
     date_start = fields.Date(required=True)
     date_end = fields.Date(required=True)
     capacity_hours = fields.Float()
     task_ids = fields.Many2many(
-        'project.task',
-        string='Stories',
+        "project.task",
+        string="Stories",
         domain="[('project_id','=',project_id), ('issue_type','=','story'), ('sprint_id','=', False)]",
     )
 
     def action_plan(self):
         self.ensure_one()
-        name = self.env.context.get('default_name') or f"Sprint {self.date_start}"
-        sprint = self.env['kb.sprint'].create(
+        name = self.env.context.get("default_name") or f"Sprint {self.date_start}"
+        sprint = self.env["kb.sprint"].create(
             {
-                'project_id': self.project_id.id,
-                'name': name,
-                'date_start': self.date_start,
-                'date_end': self.date_end,
-                'capacity_hours': self.capacity_hours,
+                "project_id": self.project_id.id,
+                "name": name,
+                "date_start": self.date_start,
+                "date_end": self.date_end,
+                "capacity_hours": self.capacity_hours,
             }
         )
-        self.task_ids.write({'sprint_id': sprint.id})
-        return {'type': 'ir.actions.act_window_close'}
-
+        self.task_ids.write({"sprint_id": sprint.id})
+        return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
## Summary
- map GitLab issues to local tasks and sync story point changes
- add wizard for sprint planning with dates, capacity and task selection
- expose backlog and sprint board views for project tasks

## Testing
- `pytest` *(fails: missing Odoo test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a72270e5f88325a82b6ad84f8acd7c