### PR TITLE
Add project portal billing endpoints

### DIFF
--- a/partenaires/bibind_portal_projects/controllers/projects.py
+++ b/partenaires/bibind_portal_projects/controllers/projects.py
@@ -84,6 +84,16 @@ class ProjectPortal(http.Controller):
 
 
     @http.route(
+        "/my/projects/<int:project_id>/milestones/<int:milestone_id>/confirm",
+        auth="user",
+        website=True,
+    )
+    def confirm_milestone(self, project_id, milestone_id, **kw):
+        milestone = request.env["kb.project.milestone"].sudo().browse(milestone_id)
+        milestone.action_confirm()
+        return request.redirect(f"/my/projects/{project_id}")
+
+    @http.route(
         "/my/projects/<int:project_id>/milestones/<int:milestone_id>/invoice",
         auth="user",
         website=True,
@@ -91,5 +101,15 @@ class ProjectPortal(http.Controller):
     def invoice_milestone(self, project_id, milestone_id, **kw):
         milestone = request.env["kb.project.milestone"].sudo().browse(milestone_id)
         milestone.action_invoice()
+        return request.redirect(f"/my/projects/{project_id}")
+
+    @http.route(
+        "/my/projects/<int:project_id>/milestones/<int:milestone_id>/paid",
+        auth="user",
+        website=True,
+    )
+    def mark_paid_milestone(self, project_id, milestone_id, **kw):
+        milestone = request.env["kb.project.milestone"].sudo().browse(milestone_id)
+        milestone.action_mark_paid()
         return request.redirect(f"/my/projects/{project_id}")
 


### PR DESCRIPTION
## Summary
- add confirm, invoice, and mark paid endpoints for project milestones
- routes allow billing actions from project portal alongside existing facade-based async operations

## Testing
- ⚠️ `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68a722fabbc0832595d2c50064cf1fb7