### PR TITLE
feat(portal-projects): add demo budget and backlog cron

### DIFF
--- a/partenaires/bibind_portal_projects/data/cron.xml
+++ b/partenaires/bibind_portal_projects/data/cron.xml
@@ -17,6 +17,24 @@
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>
         </record>
+
+        <record id="ir_cron_backlog_sync" model="ir.cron">
+            <field name="name">Backlog Sync</field>
+            <field name="model_id" ref="model_kb_projects_facade"/>
+            <field name="state">code</field>
+            <field name="code">model.sync_backlog()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">hours</field>
+        </record>
+
+        <record id="ir_cron_kpi_refresh" model="ir.cron">
+            <field name="name">KPI Refresh</field>
+            <field name="model_id" ref="model_kb_projects_facade"/>
+            <field name="state">code</field>
+            <field name="code">model.refresh_kpis()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+        </record>
     </data>
 </odoo>
 

--- a/partenaires/bibind_portal_projects/data/demo.xml
+++ b/partenaires/bibind_portal_projects/data/demo.xml
@@ -13,6 +13,27 @@
             <field name="name">Initial backlog item</field>
             <field name="project_id" ref="project_demo"/>
         </record>
+
+        <record id="budget_demo" model="kb.project.budget">
+            <field name="project_id" ref="project_demo"/>
+            <field name="labor_rate_eur_hour">80.0</field>
+        </record>
+
+        <record id="project_demo" model="project.project">
+            <field name="budget_id" ref="budget_demo"/>
+        </record>
+
+        <record id="milestone_design_demo" model="kb.project.milestone">
+            <field name="project_id" ref="project_demo"/>
+            <field name="name">Design Complete</field>
+            <field name="amount">1000</field>
+        </record>
+
+        <record id="milestone_launch_demo" model="kb.project.milestone">
+            <field name="project_id" ref="project_demo"/>
+            <field name="name">Launch</field>
+            <field name="amount">2000</field>
+        </record>
     </data>
 </odoo>
 

--- a/partenaires/bibind_portal_projects/data/mail_templates.xml
+++ b/partenaires/bibind_portal_projects/data/mail_templates.xml
@@ -4,6 +4,7 @@
             <field name="name">Sprint Notification</field>
             <field name="model_id" ref="project.model_project_project"/>
             <field name="subject">Sprint ${ctx.get('sprint_name', '')}</field>
+            <field name="email_to">${(object.user_id.email or '')|safe}</field>
             <field name="body_html"><![CDATA[
                 <p>Hello ${object.user_id.name or ''},</p>
                 <p>The sprint <strong>${ctx.get('sprint_name', '')}</strong> for project <strong>${object.name}</strong> is now available.</p>
@@ -14,6 +15,7 @@
             <field name="name">AI Notification</field>
             <field name="model_id" ref="project.model_project_project"/>
             <field name="subject">AI update for ${object.name}</field>
+            <field name="email_to">${(object.user_id.email or '')|safe}</field>
             <field name="body_html"><![CDATA[
                 <p>Hello ${object.user_id.name or ''},</p>
                 <p>The AI processing for project <strong>${object.name}</strong> is complete.</p>
@@ -24,6 +26,7 @@
             <field name="name">Milestone Notification</field>
             <field name="model_id" ref="project.model_project_project"/>
             <field name="subject">Milestone reached for ${object.name}</field>
+            <field name="email_to">${(object.user_id.email or '')|safe}</field>
             <field name="body_html"><![CDATA[
                 <p>Hello ${object.user_id.name or ''},</p>
                 <p>The milestone <strong>${ctx.get('milestone_name', '')}</strong> of project <strong>${object.name}</strong> has been reached.</p>


### PR DESCRIPTION
## Summary
- notify project users by email for sprint, AI, and milestone events
- seed demo project with budget and milestones
- schedule backlog sync and KPI refresh cron jobs

## Testing
- `pytest` *(fails: 27 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68a72a3bcc308325a09a353c528a8f4d