### PR TITLE
feat: async GitLab sync and op_bootstrap webhooks

### DIFF
--- a/partenaires/bibind_portal_projects/__manifest__.py
+++ b/partenaires/bibind_portal_projects/__manifest__.py
@@ -2,7 +2,7 @@
     'name': 'Bibind Portal Projects',
     'version': '0.1.0',
     'summary': 'Project management and GitLab integration for Bibind portal',
-    'depends': ['bibind_portal', 'project', 'mail'],
+    'depends': ['bibind_portal', 'project', 'mail', 'queue_job'],
     'data': [
         'security/ir.model.access.csv',
         'security/rules.xml',

--- a/partenaires/bibind_portal_projects/controllers/webhooks.py
+++ b/partenaires/bibind_portal_projects/controllers/webhooks.py
@@ -1,5 +1,11 @@
+import json
+import logging
+import uuid
+
 from odoo import http
 from odoo.http import request
+
+_logger = logging.getLogger(__name__)
 
 
 class GitLabWebhook(http.Controller):
@@ -15,7 +21,23 @@ class GitLabWebhook(http.Controller):
     def gitlab_webhook(self, project_id: int, **payload):
         """Trigger a synchronization for the given *project_id*."""
 
+        correlation_id = (
+            request.httprequest.headers.get("X-Correlation-Id")
+            or str(uuid.uuid4())
+        )
+        _logger.info(
+            json.dumps(
+                {
+                    "event": "gitlab.webhook",
+                    "project_id": project_id,
+                    "payload": payload,
+                    "correlation_id": correlation_id,
+                }
+            )
+        )
         request.env["kb.projects.facade"].sudo().with_context(
-            project_id=project_id
-        ).sync_gitlab()
-        return {"status": "ok"}
+            project_id=project_id, correlation_id=correlation_id
+        ).with_delay().sync_gitlab()
+        response = {"status": "queued", "correlation_id": correlation_id}
+        _logger.info(json.dumps({"response": response}))
+        return response

--- a/partenaires/bibind_portal_projects/models/orchestrators.py
+++ b/partenaires/bibind_portal_projects/models/orchestrators.py
@@ -8,6 +8,7 @@ methods required by the tests are implemented.
 from odoo import api, models
 
 from odoo.addons.bibind_core.services.api_client import ApiClient
+from odoo.addons.queue_job.job import job
 
 from __future__ import annotations
 
@@ -70,6 +71,7 @@ class ProjectsFacade(models.Model):
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+    @job
     @api.model
     def sync_gitlab(self, max_retries: int = 3):
         """Synchronize a project's backlog with GitLab.
@@ -117,10 +119,11 @@ class ProjectsFacade(models.Model):
             ("gitlab_project_id", "!=", False)
         ])
         for project in projects:
-            self.with_context(project_id=project.id).sync_gitlab()
+            self.with_context(project_id=project.id).with_delay().sync_gitlab()
         return True
 
 
+    @job
     @api.model
     def run_studio_ai(self):
         """Run a simple Studio AI task for the given project."""

--- a/partenaires/saas_partner_channel/__manifest__.py
+++ b/partenaires/saas_partner_channel/__manifest__.py
@@ -8,7 +8,8 @@
     'website': 'https://example.com',
     'depends': [
         'base', 'contacts', 'mail', 'crm', 'sale', 'sale_subscription',
-        'account', 'payment', 'website', 'portal', 'helpdesk', 'sign', 'documents'
+        'account', 'payment', 'website', 'portal', 'helpdesk', 'sign', 'documents',
+        'bibind_core'
     ],
     'data': [
         'security/rules.xml',

--- a/partenaires/saas_partner_channel/controllers/webhook.py
+++ b/partenaires/saas_partner_channel/controllers/webhook.py
@@ -1,9 +1,16 @@
 import hmac
 import hashlib
 import json
+import logging
+import uuid
+
 from odoo import http
 from odoo.http import request
 from odoo.exceptions import AccessDenied
+
+from odoo.addons.bibind_core.models.api_client import mask_secrets
+
+_logger = logging.getLogger("bibind")
 
 
 class SaasWebhook(http.Controller):
@@ -27,3 +34,50 @@ class SaasWebhook(http.Controller):
         elif event == 'tenant.failed':
             tenant.write({'status': 'failed'})
         return True
+
+    @http.route('/webhooks/op_bootstrap', type='json', auth='public', methods=['POST'], csrf=False)
+    def op_bootstrap_webhook(self):
+        secret = request.env['ir.config_parameter'].sudo().get_param('SAAS_WEBHOOK_SECRET', '')
+        signature = request.httprequest.headers.get('X-Signature')
+        body = request.httprequest.data
+        expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(expected, signature or ''):
+            _logger.warning(json.dumps({"event": "invalid_signature"}))
+            return http.Response('invalid signature', status=401)
+        payload = json.loads(body.decode())
+        correlation_id = (
+            payload.get('correlation_id')
+            or request.httprequest.headers.get('X-Correlation-Id')
+            or str(uuid.uuid4())
+        )
+        request.env = request.env(context=dict(request.env.context, correlation_id=correlation_id))
+        event = payload.get('event')
+        _logger.info(
+            json.dumps(
+                {
+                    "event": event,
+                    "payload": mask_secrets(payload),
+                    "correlation_id": correlation_id,
+                }
+            )
+        )
+        if event == 'ai.task.status':
+            request.env['bus.bus'].sendone('ai.task.status', payload)
+        elif event == 'payment.succeeded':
+            invoice_id = payload.get('invoice_id')
+            if invoice_id:
+                invoice = request.env['account.move'].sudo().search([('id', '=', invoice_id)])
+                if invoice:
+                    invoice.write({'payment_state': 'paid'})
+            _logger.info(
+                json.dumps(
+                    {
+                        "action": "payment_update",
+                        "invoice_id": payload.get('invoice_id'),
+                        "correlation_id": correlation_id,
+                    }
+                )
+            )
+        response = {'status': 'ok', 'correlation_id': correlation_id}
+        _logger.info(json.dumps({"response": response}))
+        return response


### PR DESCRIPTION
## Summary
- queue GitLab sync and AI jobs via Odoo queue_job
- log webhook traffic with correlation IDs
- add op_bootstrap webhook controller for AI status and payments

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo')*
- `pytest partenaires/bibind_portal_projects/tests/test_projects_sync.py` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_68a7433e7c38832586813e4d70bed9f8