### PR TITLE
Add bibind_website_public addon skeleton

### DIFF
--- a/partenaires/bibind_website_public/README.md
+++ b/partenaires/bibind_website_public/README.md
@@ -1,0 +1,25 @@
+# Bibind Website Public
+
+Module Odoo fournissant le site public de Bibind. Il expose des pages
+`/`, `/offers`, `/offers/<slug>`, `/docs` et `/jobs`.
+
+## Dépendances
+
+- `website`
+- `bibind_core`
+
+## Configuration
+
+Certains paramètres (URL de la documentation, base de l'API op_bootstrap) sont
+lus via `ParamStore` du module `bibind_core`.
+
+## Tests
+
+Les tests utilisent la classe `HttpCase` d'Odoo. Ils sont automatiquement
+ignorés si Odoo n'est pas disponible.
+
+Exécution :
+
+```bash
+pytest partenaires/bibind_website_public/tests
+```

--- a/partenaires/bibind_website_public/__init__.py
+++ b/partenaires/bibind_website_public/__init__.py
@@ -1,0 +1,2 @@
+"""Bibind Website Public addon."""
+from . import controllers

--- a/partenaires/bibind_website_public/__manifest__.py
+++ b/partenaires/bibind_website_public/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Manifest for Bibind Website Public addon."""
+{
+    'name': 'bibind_website_public',
+    'version': '1.0',
+    'summary': 'Public website for Bibind',
+    'category': 'Website',
+    'depends': ['website', 'bibind_core'],
+    'data': [
+        'data/website_menu.xml',
+        'data/mail_templates.xml',
+        'views/website_pages.xml',
+        'views/website_seo_templates.xml',
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            'bibind_website_public/static/src/css/theme.css',
+            'bibind_website_public/static/src/js/ui.js',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/partenaires/bibind_website_public/controllers/website.py
+++ b/partenaires/bibind_website_public/controllers/website.py
@@ -1,0 +1,157 @@
+"""Website controllers for Bibind public site.
+
+This file implements a minimal subset of the specification. The goal is to
+provide lightweight routes that can be tested without running a full Odoo
+stack.  Real deployments should expand on these handlers with full features
+such as caching, error handling and templating as described in the
+specification.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from odoo import http, _
+
+# Optional imports from bibind_core.  The try/except allows the module to be
+# imported in environments where bibind_core is not available (e.g. tests in
+# this kata repository).
+try:  # pragma: no cover - library availability depends on environment
+    from odoo.addons.bibind_core.lib.api_client import ApiClient
+    from odoo.addons.bibind_core.lib.param_store import ParamStore
+except Exception:  # pragma: no cover - executed when bibind_core is missing
+    ApiClient = object  # type: ignore
+
+    class ParamStore:  # type: ignore
+        """Fallback ParamStore used when bibind_core is unavailable."""
+
+        @staticmethod
+        def get_param(key: str, default: Optional[str] = None) -> Optional[str]:
+            return default
+
+
+_logger = logging.getLogger("bibind")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CacheItem:
+    """A tiny in-memory cache record."""
+
+    timestamp: float
+    data: Any
+
+
+class _TTLCache:
+    """Simple in-memory cache with a TTL per key."""
+
+    def __init__(self, ttl: int = 600) -> None:
+        self.ttl = ttl
+        self._store: Dict[str, CacheItem] = {}
+
+    def get(self, key: str) -> Optional[Any]:
+        item = self._store.get(key)
+        if item and (time.time() - item.timestamp) < self.ttl:
+            return item.data
+        return None
+
+    def set(self, key: str, value: Any) -> None:
+        self._store[key] = CacheItem(timestamp=time.time(), data=value)
+
+
+_cache = _TTLCache()
+
+
+def _load_jobs_data() -> list[Dict[str, Any]]:
+    """Load job definitions from the static JSON file."""
+
+    cached = _cache.get("jobs")
+    if cached is not None:
+        return cached
+    path = Path(__file__).resolve().parent.parent / "data" / "jobs.json"
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        data = []
+    _cache.set("jobs", data)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Controller
+# ---------------------------------------------------------------------------
+
+class WebsitePublicController(http.Controller):
+    """Public routes for the Bibind website."""
+
+    @http.route("/", type="http", auth="public", website=True)
+    def home(self, **kwargs: Any):
+        """Render the home page.
+
+        The real implementation would load teaser offers via ``ApiClient`` and
+        pass them to the template.  Here we only render a minimal template.
+        """
+
+        return http.request.render("bibind_website_public.index", {})
+
+    # ------------------------------------------------------------------
+    # Offers catalogue
+    # ------------------------------------------------------------------
+    @http.route("/offers", type="http", auth="public", website=True)
+    def offers(self, **kwargs: Any):
+        """List available offers."""
+        return http.request.render("bibind_website_public.offers", {})
+
+    @http.route("/offers/<string:slug>", type="http", auth="public", website=True)
+    def offer_detail(self, slug: str, **kwargs: Any):
+        """Display the detail of a single offer."""
+        # In a full implementation ``slug`` would be used to fetch data.
+        context = {"slug": slug}
+        return http.request.render("bibind_website_public.offer_detail", context)
+
+    # ------------------------------------------------------------------
+    # API documentation
+    # ------------------------------------------------------------------
+    @http.route("/docs", type="http", auth="public", website=True)
+    def docs(self, **kwargs: Any):
+        """Render the API documentation page."""
+        base_url = ParamStore.get_param("op_bootstrap_base_url", "")
+        iframe_url = f"{base_url}/openapi.yaml" if base_url else ""
+        return http.request.render("bibind_website_public.docs", {"iframe_url": iframe_url})
+
+    # ------------------------------------------------------------------
+    # Jobs
+    # ------------------------------------------------------------------
+    @http.route("/jobs", type="http", auth="public", website=True)
+    def jobs(self, q: Optional[str] = None, **kwargs: Any):
+        """Render the list of open jobs, optionally filtered by ``q``."""
+        jobs = _load_jobs_data()
+        if q:
+            q_lower = q.lower()
+            jobs = [job for job in jobs if q_lower in job.get("title", "").lower()]
+        return http.request.render("bibind_website_public.jobs", {"jobs": jobs, "query": q})
+
+    @http.route("/jobs/apply", type="http", auth="public", methods=["POST"], website=True, csrf=True)
+    def jobs_apply(self, **post: Any):
+        """Handle job application submission.
+
+        This simplified handler validates the honeypot field and required
+        parameters, then pretends to send an email using the ``mail.template``
+        defined in ``data/mail_templates.xml``.  No data is persisted.
+        """
+
+        if post.get("website_hp"):
+            return http.Response(status=400)
+        required = ["full_name", "email", "role", "message"]
+        if any(not post.get(k) for k in required):
+            return http.Response(status=400)
+        # In real deployment, ``mail.mail`` would be created here.
+        return http.local_redirect("/jobs?ok=1")

--- a/partenaires/bibind_website_public/data/jobs.json
+++ b/partenaires/bibind_website_public/data/jobs.json
@@ -1,0 +1,8 @@
+[
+    {"id": 1, "title": "Directeur", "location": "Paris", "contract": "CDI", "summary": "Piloter la vision."},
+    {"id": 2, "title": "Product Owner", "location": "Lyon", "contract": "CDI", "summary": "Porter la roadmap."},
+    {"id": 3, "title": "Développeur", "location": "Remote", "contract": "CDD", "summary": "Construire les features."},
+    {"id": 4, "title": "Architecte", "location": "Remote", "contract": "CDI", "summary": "Concevoir l'architecture."},
+    {"id": 5, "title": "Commercial", "location": "Paris", "contract": "CDI", "summary": "Développer le portefeuille."},
+    {"id": 6, "title": "DevOps", "location": "Toulouse", "contract": "CDI", "summary": "Automatiser les déploiements."}
+]

--- a/partenaires/bibind_website_public/data/mail_templates.xml
+++ b/partenaires/bibind_website_public/data/mail_templates.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="bibind_jobs_apply_mail" model="mail.template">
+        <field name="name">Bibind Job Application</field>
+        <field name="model_id" ref="base.model_res_partner"/>
+        <field name="subject">Nouvelle candidature: ${object.full_name} – ${object.role}</field>
+        <field name="body_html"><![CDATA[
+            <p>Une nouvelle candidature a été reçue.</p>
+        ]]></field>
+        <field name="email_to">hr@example.com</field>
+    </record>
+</odoo>

--- a/partenaires/bibind_website_public/data/website_menu.xml
+++ b/partenaires/bibind_website_public/data/website_menu.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem id="menu_bibind_home" name="Accueil" url="/" sequence="10"/>
+    <menuitem id="menu_bibind_offers" name="Offres" parent="menu_bibind_home" url="/offers" sequence="20"/>
+    <menuitem id="menu_bibind_docs" name="Docs" parent="menu_bibind_home" url="/docs" sequence="30"/>
+    <menuitem id="menu_bibind_jobs" name="Postes" parent="menu_bibind_home" url="/jobs" sequence="40"/>
+</odoo>

--- a/partenaires/bibind_website_public/static/src/css/theme.css
+++ b/partenaires/bibind_website_public/static/src/css/theme.css
@@ -1,0 +1,46 @@
+:root {
+    --bg: #ffffff;
+    --fg: #222222;
+    --muted: #666666;
+    --accent: #0055aa;
+}
+
+body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: sans-serif;
+    line-height: 1.6;
+    margin: 0;
+}
+
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    background: var(--accent);
+    color: #fff;
+    padding: 8px;
+}
+.skip-link:focus {
+    top: 0;
+}
+
+.hero {
+    padding: 2rem;
+    text-align: center;
+}
+
+.btn {
+    display: inline-block;
+    background: var(--accent);
+    color: #fff;
+    padding: 0.6rem 1.2rem;
+    text-decoration: none;
+}
+
+.footer {
+    padding: 1rem;
+    text-align: center;
+    background: var(--muted);
+    color: #fff;
+}

--- a/partenaires/bibind_website_public/static/src/img/logo.svg
+++ b/partenaires/bibind_website_public/static/src/img/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20"><text x="0" y="15" font-size="15">Bibind</text></svg>

--- a/partenaires/bibind_website_public/static/src/img/orchestrators.svg
+++ b/partenaires/bibind_website_public/static/src/img/orchestrators.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50"><rect width="100" height="50" fill="#0055aa"/></svg>

--- a/partenaires/bibind_website_public/static/src/js/ui.js
+++ b/partenaires/bibind_website_public/static/src/js/ui.js
@@ -1,0 +1,5 @@
+/** Minimal progressive enhancement script */
+document.addEventListener('DOMContentLoaded', function () {
+    // Example feature: log when filtering jobs (placeholder)
+    console.log('bibind_website_public ui.js loaded');
+});

--- a/partenaires/bibind_website_public/tests/test_website_routes.py
+++ b/partenaires/bibind_website_public/tests/test_website_routes.py
@@ -1,0 +1,34 @@
+"""Basic HttpCase tests for bibind_website_public.
+
+The tests rely on Odoo's testing framework. They are skipped automatically if
+Odoo is not installed in the execution environment. This allows the test suite
+of this kata repository to run without pulling the heavy Odoo dependency while
+still providing meaningful examples for real deployments.
+"""
+
+import pytest
+
+odoo = pytest.importorskip("odoo")  # noqa: F841
+from odoo.tests.common import HttpCase
+
+
+class TestWebsiteRoutes(HttpCase):
+    """Ensure that public routes are reachable."""
+
+    def test_home_200_contains_cta(self):
+        response = self.url_open("/")
+        assert response.status_code == 200
+        assert "Découvrir les offres" in response.text
+
+    def test_offers_200(self):
+        response = self.url_open("/offers")
+        assert response.status_code == 200
+
+    def test_docs_iframe_present(self):
+        response = self.url_open("/docs")
+        assert response.status_code == 200
+        assert "<iframe" in response.text
+
+    def test_jobs_get(self):
+        response = self.url_open("/jobs")
+        assert response.status_code == 200

--- a/partenaires/bibind_website_public/views/website_pages.xml
+++ b/partenaires/bibind_website_public/views/website_pages.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Layout -->
+    <template id="layout" name="Bibind Website Layout" inherit_id="website.layout">
+        <xpath expr="/t" position="inside">
+            <t t-call="bibind_website_public.seo_meta"/>
+        </xpath>
+        <xpath expr="//div[@id='wrap']" position="before">
+            <a href="#main" class="skip-link">Skip to content</a>
+        </xpath>
+        <xpath expr="//div[@id='wrap']" position="replace">
+            <div id="wrap">
+                <header role="banner">
+                    <nav role="navigation" aria-label="Main navigation">
+                        <ul>
+                            <li><a href="/">Home</a></li>
+                            <li><a href="/offers">Offers</a></li>
+                            <li><a href="/docs">Docs</a></li>
+                            <li><a href="/jobs">Jobs</a></li>
+                        </ul>
+                    </nav>
+                </header>
+                <main id="main" role="main">
+                    <t t-raw="0"/>
+                </main>
+                <footer class="footer">
+                    <p>&copy; <t t-esc="datetime.datetime.utcnow().year"/></p>
+                </footer>
+            </div>
+        </xpath>
+    </template>
+
+    <!-- Home page -->
+    <template id="index" name="Bibind Home" page="True" inherit_id="bibind_website_public.layout">
+        <xpath expr="//main" position="inside">
+            <section class="hero">
+                <h1>Bienvenue sur Bibind</h1>
+                <p>Votre plateforme d'orchestration.</p>
+                <p><a class="btn" href="/offers">Découvrir les offres</a></p>
+            </section>
+        </xpath>
+    </template>
+
+    <!-- Offers catalogue -->
+    <template id="offers" name="Bibind Offers" page="True" inherit_id="bibind_website_public.layout">
+        <xpath expr="//main" position="inside">
+            <h1>Catalogue d'offres</h1>
+            <div class="offers-grid">
+                <t t-foreach="[]" t-as="o">
+                    <div class="card"><t t-esc="o"/></div>
+                </t>
+            </div>
+        </xpath>
+    </template>
+
+    <!-- Offer detail -->
+    <template id="offer_detail" name="Bibind Offer Detail" page="True" inherit_id="bibind_website_public.layout">
+        <xpath expr="//main" position="inside">
+            <h1><t t-esc="slug"/></h1>
+            <p>Details coming soon.</p>
+        </xpath>
+    </template>
+
+    <!-- Docs page -->
+    <template id="docs" name="Bibind Docs" page="True" inherit_id="bibind_website_public.layout">
+        <xpath expr="//main" position="inside">
+            <h1>API Documentation</h1>
+            <iframe t-att-src="iframe_url" style="width:100%;height:80vh" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
+            <p><a t-if="iframe_url" t-att-href="iframe_url">Télécharger l'OpenAPI</a></p>
+        </xpath>
+    </template>
+
+    <!-- Jobs page -->
+    <template id="jobs" name="Bibind Jobs" page="True" inherit_id="bibind_website_public.layout">
+        <xpath expr="//main" position="inside">
+            <h1>Postes ouverts</h1>
+            <ul>
+                <t t-foreach="jobs" t-as="job">
+                    <li><t t-esc="job['title']"/> – <t t-esc="job['location']"/></li>
+                </t>
+            </ul>
+            <form action="/jobs/apply" method="post" enctype="multipart/form-data">
+                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                <input type="hidden" name="website_hp" value=""/>
+                <label for="full_name">Nom</label>
+                <input id="full_name" name="full_name" required="required"/>
+                <label for="email">Email</label>
+                <input id="email" name="email" type="email" required="required"/>
+                <label for="role">Poste</label>
+                <input id="role" name="role" required="required"/>
+                <label for="message">Message</label>
+                <textarea id="message" name="message" required="required"></textarea>
+                <label for="cv">CV</label>
+                <input id="cv" name="cv" type="file"/>
+                <label><input type="checkbox" name="consent" required="required"/> J'accepte</label>
+                <button type="submit" class="btn">Envoyer</button>
+            </form>
+        </xpath>
+    </template>
+</odoo>

--- a/partenaires/bibind_website_public/views/website_seo_templates.xml
+++ b/partenaires/bibind_website_public/views/website_seo_templates.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- SEO templates loaded into layout -->
+    <template id="seo_meta" name="Bibind SEO Meta">
+        <t t-set="title">Bibind</t>
+        <t t-set="description">Bibind public website</t>
+        <t t-set="og_title">Bibind</t>
+        <t t-set="og_description">Bibind public website</t>
+    </template>
+</odoo>


### PR DESCRIPTION
## Summary
- add public website addon skeleton with core pages and routes
- include basic static assets, data files and tests
- remove binary hero image asset

## Testing
- `pytest partenaires/bibind_website_public/tests/test_website_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6c1c26acc8325887ca0f2c441c27b